### PR TITLE
Fix "may be used uninitialized" error with -O2 optimization

### DIFF
--- a/erpc_c/infra/erpc_basic_codec.cpp
+++ b/erpc_c/infra/erpc_basic_codec.cpp
@@ -262,7 +262,7 @@ void BasicCodec::read(double *value)
 
 void BasicCodec::readPtr(uintptr_t *value)
 {
-    uint8_t ptrSize;
+    uint8_t ptrSize = ~0;
 
     read(&ptrSize);
 


### PR DESCRIPTION
This PR fixes the following error that occurs when the SCPU firmware (and therefore eRPC) is compiled with `-O2` optimization:
```
...
/home/berend/scorpio-fw-9/modules/saas/modules/erpc/erpc_c/infra/erpc_basic_codec.cpp: In member function 'virtual void erpc::BasicCodec::readPtr(uintptr_t*)':
/home/berend/scorpio-fw-9/modules/saas/modules/erpc/erpc_c/infra/erpc_basic_codec.cpp:271:17: error: 'ptrSize' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  271 |     if (ptrSize > sizeof(*value))
      |         ~~~~~~~~^~~~~~~~~~~~~~~~
...
```
Specifically what's occurring is that as part of the deeper analysis and inlining that takes place when `-O2` is in effect, the compiler is able to "see" that the `read()` call [here](https://github.com/recogni/erpc/blob/37e6f934c698145723c71ce73fa7cd189b9dfc94/erpc_c/infra/erpc_basic_codec.cpp#L267) to read a value into `ptrSize` _may not actually deposit a value_ if the underlying `readData()` call fails to pass [this](https://github.com/recogni/erpc/blob/37e6f934c698145723c71ce73fa7cd189b9dfc94/erpc_c/infra/erpc_basic_codec.cpp#L196) condition.

Since `readPtr()` already has an error path for the case that the read value is too large [here](https://github.com/recogni/erpc/blob/37e6f934c698145723c71ce73fa7cd189b9dfc94/erpc_c/infra/erpc_basic_codec.cpp#L269-L272), initializing the `ptrSize` to an absurdly-large pointer size takes care of the "may be used uninitialized" error by falling into the existing error path.

This is needed as part of addressing https://github.com/recogni/scorpio-fw/issues/1072.