### PR TITLE
Added CPP client code generation

### DIFF
--- a/erpcgen/Makefile
+++ b/erpcgen/Makefile
@@ -57,6 +57,7 @@ SOURCES += $(OBJS_ROOT)/erpcgen_parser.tab.cpp \
 			$(ERPC_ROOT)/erpcgen/src/AstWalker.cpp \
 			$(ERPC_ROOT)/erpcgen/src/UniqueIdChecker.cpp \
 			$(ERPC_ROOT)/erpcgen/src/CGenerator.cpp \
+            $(ERPC_ROOT)/erpcgen/src/CPPGenerator.cpp \
 			$(ERPC_ROOT)/erpcgen/src/PythonGenerator.cpp \
 			$(ERPC_ROOT)/erpcgen/src/erpcgen.cpp \
 			$(ERPC_ROOT)/erpcgen/src/ErpcLexer.cpp \
@@ -72,12 +73,15 @@ SOURCES += $(OBJS_ROOT)/erpcgen_parser.tab.cpp \
 .SECONDARY: $(OBJS_ROOT)/erpcgen_parser.tab.cpp \
             $(OBJS_ROOT)/erpcgen_lexer.cpp \
             $(OBJS_ROOT)/erpcgen/src/templates/c_common_header.c \
+            $(OBJS_ROOT)/erpcgen/src/templates/cpp_common_header.c \
             $(OBJS_ROOT)/erpcgen/src/templates/c_client_source.c \
+            $(OBJS_ROOT)/erpcgen/src/templates/cpp_client_source.c \
             $(OBJS_ROOT)/erpcgen/src/templates/c_server_header.c \
             $(OBJS_ROOT)/erpcgen/src/templates/c_server_source.c \
             $(OBJS_ROOT)/erpcgen/src/templates/c_coders.c \
             $(OBJS_ROOT)/erpcgen/src/templates/c_common_functions.c \
             $(OBJS_ROOT)/erpcgen/src/templates/c_crc.c \
+            $(OBJS_ROOT)/erpcgen/src/templates/cpp_crc.c \
             $(OBJS_ROOT)/erpcgen/src/templates/py_init.c \
             $(OBJS_ROOT)/erpcgen/src/templates/py_common.c \
             $(OBJS_ROOT)/erpcgen/src/templates/py_client.c \
@@ -96,12 +100,15 @@ SOURCES +=  $(ERPC_ROOT)/erpcgen/VisualStudio_v14/c_common_header.cpp \
             $(OBJS_ROOT)/erpcgen/src/templates/c_crc.cpp
 else
 SOURCES +=  $(OBJS_ROOT)/erpcgen/src/templates/c_common_header.c \
+            $(OBJS_ROOT)/erpcgen/src/templates/cpp_common_header.c \
             $(OBJS_ROOT)/erpcgen/src/templates/c_client_source.c \
+            $(OBJS_ROOT)/erpcgen/src/templates/cpp_client_source.c \
             $(OBJS_ROOT)/erpcgen/src/templates/c_server_header.c \
             $(OBJS_ROOT)/erpcgen/src/templates/c_server_source.c \
             $(OBJS_ROOT)/erpcgen/src/templates/c_coders.c \
             $(OBJS_ROOT)/erpcgen/src/templates/c_common_functions.c \
             $(OBJS_ROOT)/erpcgen/src/templates/c_crc.c \
+            $(OBJS_ROOT)/erpcgen/src/templates/cpp_crc.c \
             $(OBJS_ROOT)/erpcgen/src/templates/py_init.c \
             $(OBJS_ROOT)/erpcgen/src/templates/py_common.c \
             $(OBJS_ROOT)/erpcgen/src/templates/py_client.c \
@@ -164,6 +171,11 @@ $(OBJS_ROOT)/erpcgen_parser.tab.hpp: $(ERPC_ROOT)/erpcgen/src/erpcgen_parser.y |
 $(OBJS_ROOT)/%.c: $(ERPC_ROOT)/%.template
 	@$(call printmessage,orange,Converting, $(subst $(ERPC_ROOT)/,,$<))
 	$(at)$(mkdirc) -p $(dir $@) && $(PYTHON) $(ERPC_ROOT)/$(PYTH_SCRIPT) -o $@ $<
+
+# $(OBJS_ROOT)/cpp_%.cpp: $(ERPC_ROOT)/cpp_%.template
+# 	@$(call printmessage,orange,Converting, $(subst $(ERPC_ROOT)/,,$<))
+# 	$(at)$(mkdirc) -p $(dir $@) && $(PYTHON) $(ERPC_ROOT)/$(PYTH_SCRIPT) -o $@ $<
+
 
 .PHONY: install
 install: $(MAKE_TARGET)

--- a/erpcgen/VisualStudio_v14/.gitignore
+++ b/erpcgen/VisualStudio_v14/.gitignore
@@ -5,13 +5,16 @@ erpcgen_parser.tab.hpp
 
 # templates
 c_client_source.cpp
+cpp_client_source.cpp
 c_coders.cpp
 c_common_header.cpp
+cpp_common_header.cpp
 c_server_header.cpp
 c_server_source.cpp
 c_common_functions.cpp
 c_defines.cpp
 c_crc.cpp
+cpp_crc.cpp
 py_client.cpp
 py_coders.cpp
 py_common.cpp

--- a/erpcgen/src/CPPGenerator.cpp
+++ b/erpcgen/src/CPPGenerator.cpp
@@ -1,0 +1,3527 @@
+/*
+ * Copyright (c) 2014-2016, Freescale Semiconductor, Inc.
+ * Copyright 2016-2020 NXP
+ * All rights reserved.
+ *
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "CPPGenerator.h"
+
+#include "Logging.h"
+#include "ParseErrors.h"
+#include "annotations.h"
+#include "format_string.h"
+
+#include <algorithm>
+#include <set>
+#include <sstream>
+
+using namespace erpcgen;
+using namespace cpptempl;
+using namespace std;
+
+////////////////////////////////////////////////////////////////////////////////
+// Variables
+////////////////////////////////////////////////////////////////////////////////
+
+/*! @brief Set of characters that are allowed in C language identifiers. */
+static const char *const kIdentifierChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_";
+
+// Templates strings converted from text files by txt_to_c.py.
+extern const char *const kCppCommonHeader;
+extern const char *const kCServerHeader;
+extern const char *const kCppClientSource;
+extern const char *const kCServerSource;
+extern const char *const kCCoders;
+extern const char *const kCCommonFunctions;
+extern const char *const kCppCrc;
+
+// number which makes list temporary variables unique.
+static uint8_t listCounter = 0;
+
+////////////////////////////////////////////////////////////////////////////////
+// Code
+////////////////////////////////////////////////////////////////////////////////
+CPPGenerator::CPPGenerator(InterfaceDefinition *def)
+: Generator(def, kCPP)
+{
+    /* Set copyright rules. */
+    if (m_def->hasProgramSymbol())
+    {
+        Program *program = m_def->getProgramSymbol();
+        string copyright = program->getMlComment();
+        if (copyright.size() >= 3 && (copyright[2] == '*' || copyright[2] == '!'))
+        {
+            copyright = copyright.substr(0, 2) + copyright.substr(3, copyright.size() - 3);
+            program->setMlComment(copyright);
+        }
+        setTemplateComments(program, m_templateData);
+    }
+    else
+    {
+        m_templateData["mlComment"] = "";
+        m_templateData["ilComment"] = "";
+    }
+
+    initCReservedWords();
+}
+
+void CPPGenerator::generateOutputFiles(const string &fileName)
+{
+    generateClientSourceFile(fileName);
+    generateCommonHeaderFiles(fileName);
+}
+
+void CPPGenerator::generateTypesHeaderFile()
+{
+    string typesHeaderFileName = m_templateData["commonTypesFile"]->getvalue();
+
+    m_templateData["commonGuardMacro"] = generateIncludeGuardName(typesHeaderFileName);
+    m_templateData["genCommonTypesFile"] = true;
+    m_templateData["commonTypesFile"] = "";
+
+    generateOutputFile(typesHeaderFileName, "cpp_common_header", m_templateData, kCppCommonHeader);
+}
+
+void CPPGenerator::generateCommonHeaderFiles(const string &fileName)
+{
+    m_templateData["commonGuardMacro"] = generateIncludeGuardName(fileName + ".h");
+    m_templateData["genCommonTypesFile"] = false;
+
+    generateOutputFile(fileName + ".h", "cpp_common_header", m_templateData, kCppCommonHeader);
+}
+
+void CPPGenerator::generateClientSourceFile(string fileName)
+{
+    m_templateData["source"] = "client";
+    fileName += "_client.cpp";
+    m_templateData["clientSourceName"] = fileName;
+
+    // TODO: temporary workaround for tests
+    m_templateData["unitTest"] = (fileName.compare("test_unit_test_common_client.cpp") == 0 ? false : true);
+
+    generateOutputFile(fileName, "cpp_client_source", m_templateData, kCppClientSource);
+}
+
+void CPPGenerator::generateServerHeaderFile(string fileName)
+{
+    throw std::runtime_error("E_NOT_IMPLEMENTED::generateServerHeaderFile");
+}
+
+void CPPGenerator::generateServerSourceFile(string fileName)
+{
+    throw std::runtime_error("E_NOT_IMPLEMENTED::generateServerSourceFile");
+}
+
+void CPPGenerator::generateCrcFile()
+{
+    string filename = "erpc_crc16.h";
+    m_templateData["crcGuardMacro"] = generateIncludeGuardName(filename);
+    generateOutputFile(filename, "cpp_crc", m_templateData, kCppCrc);
+}
+
+void CPPGenerator::parseSubtemplates()
+{
+    string templateName = "c_coders";
+    try
+    {
+        parse(kCCoders, m_templateData);
+        templateName = "c_common_functions";
+        parse(kCCommonFunctions, m_templateData);
+    }
+    catch (TemplateException &e)
+    {
+        throw TemplateException(format_string("Template %s: %s", templateName.c_str(), e.what()));
+    }
+}
+
+DataType *CPPGenerator::findChildDataType(set<DataType *> &dataTypes, DataType *dataType)
+{
+    // Detecting loops from forward declarations.
+    // Insert data type into set
+    if (!(dataType->isBinary() || dataType->isList()))
+    {
+        if (!dataTypes.insert(dataType).second)
+        {
+            return dataType;
+        }
+    }
+
+    switch (dataType->getDataType())
+    {
+        case DataType::kAliasType: {
+            AliasType *aliasType = dynamic_cast<AliasType *>(dataType);
+            assert(aliasType);
+            aliasType->setElementType(findChildDataType(dataTypes, aliasType->getElementType()));
+            break;
+        }
+        case DataType::kArrayType: {
+            ArrayType *arrayType = dynamic_cast<ArrayType *>(dataType);
+            assert(arrayType);
+            arrayType->setElementType(findChildDataType(dataTypes, arrayType->getElementType()));
+            break;
+        }
+        case DataType::kBuiltinType: {
+            if (dataType->isBinary())
+            {
+                // check if binary data type was replaced with structure wrapper
+                dataType = dynamic_cast<DataType *>(m_globals->getSymbol("binary_t"));
+                if (!dataType)
+                {
+                    // Replace binary with list<uint8>
+                    BuiltinType *builtinType = dynamic_cast<BuiltinType *>(m_globals->getSymbol("uint8"));
+                    assert(builtinType);
+                    ListType *listType = new ListType(builtinType);
+                    BuiltinType *replacedBuiltinType = dynamic_cast<BuiltinType *>(m_globals->getSymbol("binary"));
+                    assert(replacedBuiltinType);
+
+                    StructType *newStruct = new StructType("binary_t");
+                    StructMember *elements = new StructMember("data", listType);
+                    elements->setContainList(true);
+                    elements->setContainString(false);
+                    newStruct->addMember(elements);
+                    newStruct->getScope().setParent(m_globals);
+
+                    m_globals->replaceSymbol(replacedBuiltinType, newStruct);
+                    m_listBinaryTypes.insert(m_listBinaryTypes.begin(), listType);
+
+                    dataType = dynamic_cast<DataType *>(m_globals->getSymbol("binary_t"));
+                    assert(dataType);
+                }
+            }
+            dataTypes.insert(dataType);
+            break;
+        }
+        case DataType::kFunctionType: {
+            FunctionType *funcType = dynamic_cast<FunctionType *>(dataType);
+            assert(funcType);
+
+            // Only for detecting loop from forward declaration.
+            set<DataType *> localDataTypes;
+            localDataTypes.insert(dataTypes.begin(), dataTypes.end());
+
+            // handle return value
+            StructMember *returnType = funcType->getReturnStructMemberType();
+            DataType *transformedDataType = findChildDataType(localDataTypes, funcType->getReturnType());
+            returnType->setDataType(transformedDataType);
+
+            // handle function parameters
+            auto params = funcType->getParameters().getMembers();
+            for (auto mit : params)
+            {
+                setBinaryList(mit);
+
+                mit->setDataType(findChildDataType(localDataTypes, mit->getDataType()));
+            }
+            break;
+        }
+        case DataType::kListType: {
+            // The only child node of a list node is the element type.
+            ListType *listType = dynamic_cast<ListType *>(dataType);
+            DataType *trueContainerDataType = listType->getTrueContainerDataType();
+            assert(listType);
+            DataType *elementType = findChildDataType(dataTypes, listType->getElementType());
+            listType->setElementType(elementType);
+
+            // If the list has a length variable, we do need to create a list struct.
+            // Instead, we leave the list data type as is, and use that information
+            // to generate template data.
+            if (listType->hasLengthVariable())
+            {
+                Log::debug("list of type %s has length variable %s\n", listType->getElementType()->getName().c_str(),
+                           listType->getLengthVariableName().c_str());
+                break;
+            }
+            else
+            {
+                // Check if list already exist. If yes then use existing list. We need it for generating only one
+                // send/received method.
+                uint32_t nameCount = 1;
+
+                string structName =
+                    format_string("list_%s_%d_t", getOutputName(trueContainerDataType, false).c_str(), nameCount);
+                Symbol *symbol = m_globals->getSymbol(structName);
+                while (symbol != nullptr)
+                {
+                    DataType *symDataType = dynamic_cast<DataType *>(symbol);
+                    assert(symDataType);
+                    if (symDataType->getTrueDataType()->isStruct())
+                    {
+                        StructType *structType = dynamic_cast<StructType *>(symDataType);
+                        assert(structType);
+
+                        // For sure that structure hasn't zero members. Also this type of structure has only one member.
+                        if (isListStruct(structType))
+                        {
+                            // use same structs to send same lists data types (including lists using alias name)
+                            ListType *oldlistType =
+                                dynamic_cast<ListType *>(structType->getMembers()[0]->getDataType());
+                            assert(oldlistType);
+                            if (oldlistType->getElementType()->getTrueDataType()->getName() ==
+                                elementType->getTrueDataType()->getName())
+                            {
+                                dataType = symDataType;
+                                dataTypes.insert(dataType);
+                                return dataType;
+                            }
+                        }
+                    }
+
+                    // search for next list
+                    ++nameCount;
+                    structName =
+                        format_string("list_%s_%d_t", getOutputName(trueContainerDataType, false).c_str(), nameCount);
+                    symbol = m_globals->getSymbol(structName);
+                }
+
+                // if don't, create new one.
+                StructType *newStruct = new StructType(structName);
+                StructMember *elements = new StructMember("elements", listType);
+                elements->setContainList(true);
+                elements->setContainString(containsString(elementType));
+                newStruct->addMember(elements);
+                newStruct->getScope().setParent(m_globals);
+
+                m_structListTypes.push_back(newStruct);
+
+                // Add newStruct at right place in m_globals.
+                int symbolPos;
+                // if list element is transformed list or structure then this will allow add this list after it.
+                if (trueContainerDataType->isStruct())
+                {
+                    symbolPos = m_globals->getSymbolPos(trueContainerDataType) + 1;
+                }
+                else
+                {
+                    // list <base types> will be at the beginning of structures declarations.
+                    // This is will sort them in order as they were used.
+                    static int s_symbolPos = 0;
+                    symbolPos = s_symbolPos++;
+                }
+
+                // put new structure definition in globals before this structure
+                m_globals->addSymbol(newStruct, symbolPos);
+
+                dataType = newStruct;
+                dataTypes.insert(dataType);
+                break;
+            }
+        }
+        case DataType::kStructType: {
+            StructType *structType = dynamic_cast<StructType *>(dataType);
+            assert(structType);
+
+            if (isBinaryStruct(structType) || isListStruct(structType))
+            {
+                DataType *memberDataType = structType->getMembers()[0]->getDataType();
+                if (memberDataType->isList())
+                {
+                    ListType *memberListDataType = dynamic_cast<ListType *>(memberDataType);
+                    findChildDataType(dataTypes, memberListDataType->getElementType());
+                }
+                break;
+            }
+
+            for (StructMember *structMember : structType->getMembers())
+            {
+                setBinaryList(structMember);
+                setNoSharedAnn(structType, structMember);
+                structMember->setDataType(findChildDataType(dataTypes, structMember->getDataType()));
+                structMember->setContainList(containsList(structMember->getDataType()));
+                structMember->setContainString(containsString(structMember->getDataType()));
+            }
+            break;
+        }
+        case DataType::kUnionType: {
+            // Keil need extra pragma option when unions are used.
+            m_templateData["usedUnionType"] = true;
+            UnionType *currentUnion = dynamic_cast<UnionType *>(dataType);
+            assert(currentUnion);
+
+            for (auto unionMember : currentUnion->getUnionMembers().getMembers())
+            {
+                setBinaryList(unionMember);
+                setNoSharedAnn(currentUnion, unionMember);
+                unionMember->setDataType(findChildDataType(dataTypes, unionMember->getDataType()));
+            }
+            break;
+        }
+        default: {
+            break;
+        }
+    }
+
+    return dataType;
+}
+
+void CPPGenerator::transformAliases()
+{
+    for (auto it : m_globals->getSymbolsOfType(DataType::kAliasTypeSymbol))
+    {
+        AliasType *aliasType = dynamic_cast<AliasType *>(it);
+        assert(aliasType);
+
+        set<DataType *> dataTypesNew;
+        findChildDataType(dataTypesNew, aliasType);
+    }
+}
+
+void CPPGenerator::setBinaryList(StructMember *structMember)
+{
+    DataType *dataType = structMember->getDataType();
+    if (dataType->isBinary())
+    {
+        Annotation *listLength = findAnnotation(structMember, LENGTH_ANNOTATION);
+        if (listLength)
+        {
+            BuiltinType *builtinType = dynamic_cast<BuiltinType *>(m_globals->getSymbol("uint8"));
+            assert(builtinType);
+            ListType *listType = new ListType(builtinType);
+            structMember->setDataType(listType);
+            listType->setLengthVariableName(listLength->getValueObject()->toString());
+            m_listBinaryTypes.push_back(listType);
+        }
+    }
+}
+
+void CPPGenerator::generate()
+{
+    Program *program = nullptr;
+    bool generateAllocErrorChecks = true;
+    bool generateInfraErrorChecks = true;
+    if (m_def->hasProgramSymbol())
+    {
+        program = m_def->getProgramSymbol();
+        generateAllocErrorChecks = (findAnnotation(program, NO_ALLOC_ERRORS_ANNOTATION) == nullptr);
+        generateInfraErrorChecks = (findAnnotation(program, NO_INFRA_ERRORS_ANNOTATION) == nullptr);
+    }
+    /* Generate file with shim code version. */
+    m_templateData["versionGuardMacro"] =
+        generateIncludeGuardName(format_string("erpc_generated_shim_code_crc_%d", m_idlCrc16).c_str());
+
+    m_templateData["generateInfraErrorChecks"] = generateInfraErrorChecks;
+    m_templateData["generateAllocErrorChecks"] = generateAllocErrorChecks;
+    m_templateData["generateErrorChecks"] = generateInfraErrorChecks || generateAllocErrorChecks;
+
+    data_list empty;
+    m_templateData["enums"] = empty;
+    m_templateData["aliases"] = empty;
+    m_templateData["structs"] = empty;
+    m_templateData["unions"] = empty;
+    m_templateData["consts"] = empty;
+    m_templateData["functions"] = empty;
+
+    m_templateData["nonExternalStructUnion"] = false;
+
+    // Keil need extra pragma option when unions are used.
+    m_templateData["usedUnionType"] = false;
+
+    /* Set directions constants*/
+    m_templateData["InDirection"] = getDirection(kInDirection);
+    m_templateData["OutDirection"] = getDirection(kOutDirection);
+    m_templateData["InoutDirection"] = getDirection(kInoutDirection);
+    m_templateData["ReturnDirection"] = getDirection(kReturn);
+
+    parseSubtemplates();
+
+    /* Generate file containing crc of IDL files. */
+    if (m_def->hasProgramSymbol() && findAnnotation(program, CRC_ANNOTATION) != nullptr)
+    {
+        generateCrcFile();
+    }
+
+    // check if structure/function parameters annotations are valid.
+    for (Symbol *symbol : m_globals->getSymbolsOfType(Symbol::kFunctionTypeSymbol))
+    {
+        FunctionType *functionType = dynamic_cast<FunctionType *>(symbol);
+        assert(functionType);
+        scanStructForAnnotations(&functionType->getParameters(), true);
+    }
+
+    for (Symbol *symbol : m_globals->getSymbolsOfType(Symbol::kStructTypeSymbol))
+    {
+        StructType *structType = dynamic_cast<StructType *>(symbol);
+        assert(structType);
+        scanStructForAnnotations(structType, false);
+    }
+
+    for (Symbol *symbol : m_globals->getSymbolsOfType(Symbol::kInterfaceSymbol))
+    {
+        Interface *interface = dynamic_cast<Interface *>(symbol);
+        assert(interface);
+        for (Function *function : interface->getFunctions())
+        {
+            scanStructForAnnotations(&function->getParameters(), true);
+        }
+    }
+
+    // transform alias data types
+    transformAliases();
+
+    // transform data types and populate groups symbol map with all symbol directions
+    findGroupDataTypes();
+
+    makeIncludesTemplateData();
+
+    makeAliasesTemplateData();
+
+    makeConstTemplateData();
+
+    makeEnumsTemplateData();
+
+    // for common header, only C specific
+    makeSymbolsDeclarationTemplateData();
+
+    // check if types header annotation is used
+    if (m_def->hasProgramSymbol())
+    {
+        m_templateData["commonTypesFile"] = getAnnStringValue(program, TYPES_HEADER_ANNOTATION);
+    }
+    else
+    {
+        m_templateData["commonTypesFile"] = "";
+    }
+
+    for (Group *group : m_groups)
+    {
+        data_map groupTemplate;
+        groupTemplate["name"] = group->getName();
+        groupTemplate["includes"] = makeGroupIncludesTemplateData(group);
+        groupTemplate["symbolsMap"] = makeGroupSymbolsTemplateData(group);
+        groupTemplate["interfaces"] = makeGroupInterfacesTemplateData(group);
+        groupTemplate["callbacks"] = makeGroupCallbacksTemplateData(group);
+        group->setTemplate(groupTemplate);
+
+        generateGroupOutputFiles(group);
+    }
+
+    // generate types header if used
+    if (!m_templateData["commonTypesFile"]->getvalue().empty())
+    {
+        generateTypesHeaderFile();
+    }
+}
+
+void CPPGenerator::makeConstTemplateData()
+{
+    Log::info("Constant globals:\n");
+    data_list consts;
+    for (auto it : m_globals->getSymbolsOfType(Symbol::kConstSymbol))
+    {
+        ConstType *constVar = dynamic_cast<ConstType *>(it);
+        assert(constVar);
+        data_map constInfo;
+        if (!findAnnotation(constVar, EXTERNAL_ANNOTATION))
+        {
+            DataType *constVarType = dynamic_cast<DataType *>(constVar->getDataType());
+            assert(constVarType);
+            Value *constVarValue = constVar->getValue();
+
+            if (nullptr == constVarValue)
+            {
+                throw semantic_error(
+                    format_string("line %d: Const pointing to null Value object.", constVar->getLastLine()).c_str());
+            }
+
+            /* Use char[] for constants. */
+            if (constVarType->getTrueDataType()->isString())
+            {
+                constInfo["typeAndName"] = format_string("char %s [%d]", getOutputName(constVar).c_str(),
+                                                         constVarValue->toString().size() + 1);
+            }
+            else
+            {
+                constInfo["typeAndName"] = getTypenameName(constVarType, getOutputName(constVar));
+            }
+            constInfo["name"] = getOutputName(constVar);
+
+            string value;
+            if (constVarType->isEnum())
+            {
+                if (constVarValue->getType() != kIntegerValue)
+                {
+                    throw semantic_error(format_string("line %d: Const enum pointing to non-integer Value object.",
+                                                       constVar->getLastLine())
+                                             .c_str());
+                }
+
+                EnumType *constEnum = dynamic_cast<EnumType *>(constVarType);
+                assert(constEnum);
+                for (EnumMember *enumMember : constEnum->getMembers())
+                {
+                    assert(dynamic_cast<IntegerValue *>(constVarValue));
+                    if (enumMember->getValue() == dynamic_cast<IntegerValue *>(constVarValue)->getValue())
+                    {
+                        value = enumMember->getName();
+                        break;
+                    }
+                }
+                if (value.compare("") == 0)
+                {
+                    value = "(" + constVarType->getName() + ") " + constVarValue->toString();
+                    Log::warning(format_string("Enum value '%s' is not pointing to any '%s' variable \n",
+                                               constVarValue->toString().c_str(), constVarType->getName().c_str())
+                                     .c_str());
+                }
+            }
+            else
+            {
+                value = constVarValue->toString();
+                if (kStringValue == constVarValue->getType())
+                {
+                    value = "\"" + value + "\"";
+                }
+            }
+            constInfo["value"] = value;
+
+            setTemplateComments(constVar, constInfo);
+            Log::info("Name=%s\tType=%s\tValue=%s\n", constVar->getName().c_str(), constVarType->getName().c_str(),
+                      constVar->getValue()->toString().c_str());
+            consts.push_back(constInfo);
+        }
+    }
+    m_templateData["consts"] = consts;
+}
+
+void CPPGenerator::makeEnumsTemplateData()
+{
+    Log::info("Enums:\n");
+    data_list enums;
+    int n = 0;
+    for (auto it : m_globals->getSymbolsOfType(DataType::kEnumTypeSymbol))
+    {
+        EnumType *enumType = dynamic_cast<EnumType *>(it);
+        assert(enumType);
+        if (!findAnnotation(enumType, EXTERNAL_ANNOTATION))
+        {
+            Log::info("%d: %s\n", n, enumType->getName().c_str());
+            enums.push_back(getEnumTemplateData(enumType));
+            ++n;
+        }
+    }
+    m_templateData["enums"] = enums;
+}
+
+data_map CPPGenerator::getEnumTemplateData(EnumType *enumType)
+{
+    data_map enumInfo;
+    enumInfo["name"] = getOutputName(enumType);
+    enumInfo["members"] = getEnumMembersTemplateData(enumType);
+    setTemplateComments(enumType, enumInfo);
+    return enumInfo;
+}
+
+data_list CPPGenerator::getEnumMembersTemplateData(EnumType *enumType)
+{
+    unsigned int j = 0;
+    data_list enumMembersList;
+    for (auto member : enumType->getMembers())
+    {
+        assert(member->hasValue());
+        data_map enumMember;
+        string memberDeclaration = getOutputName(member);
+        if (member->hasValue())
+        {
+            memberDeclaration = format_string("%s = %d", memberDeclaration.c_str(), member->getValue());
+        }
+        if (j + 1 < enumType->getMembers().size())
+        {
+            memberDeclaration += ",";
+        }
+        enumMember["memberDeclaration"] = memberDeclaration;
+        Log::info("    %d: %s = %d\n", j, member->getName().c_str(), member->getValue());
+        setTemplateComments(member, enumMember);
+        enumMembersList.push_back(enumMember);
+        ++j;
+    }
+    return enumMembersList;
+}
+
+void CPPGenerator::makeAliasesTemplateData()
+{
+    Log::info("Type definition:\n");
+    data_list aliases;
+    int n = 0;
+
+    // All existing type declarations
+    SymbolScope::symbol_vector_t aliasTypeVector = m_globals->getSymbolsOfType(DataType::kAliasTypeSymbol);
+
+    /* type definitions of structures */
+    int i = 0;
+    for (auto it : m_globals->getSymbolsOfType(DataType::kStructTypeSymbol))
+    {
+        StructType *structType = dynamic_cast<StructType *>(it);
+        assert(structType);
+        if (structType->getName().compare("") != 0 && !findAnnotation(structType, EXTERNAL_ANNOTATION))
+        {
+            AliasType *a = new AliasType(getOutputName(structType), structType);
+            aliasTypeVector.insert(aliasTypeVector.begin() + i++, a);
+        }
+    }
+
+    /* type definitions of non-encapsulated unions */
+    for (auto it : m_globals->getSymbolsOfType(DataType::kUnionTypeSymbol))
+    {
+        UnionType *unionType = dynamic_cast<UnionType *>(it);
+        assert(unionType);
+        if (!findAnnotation(unionType, EXTERNAL_ANNOTATION))
+        {
+            AliasType *a = new AliasType(getOutputName(unionType), unionType);
+            aliasTypeVector.insert(aliasTypeVector.begin() + i++, a);
+        }
+    }
+
+    /* type definitions of functions and table of functions */
+    data_list functions;
+    for (Symbol *functionTypeSymbol : m_globals->getSymbolsOfType(Symbol::kFunctionTypeSymbol))
+    {
+        FunctionType *functionType = dynamic_cast<FunctionType *>(functionTypeSymbol);
+        assert(functionType);
+        data_map functionInfo;
+
+        // aware of external function definitions
+        if (!findAnnotation(functionType, EXTERNAL_ANNOTATION))
+        {
+            AliasType *a = new AliasType(getFunctionPrototype(nullptr, functionType), functionType);
+            a->setMlComment(functionType->getMlComment());
+            a->setIlComment(functionType->getIlComment());
+
+            /* Function type definition need be inserted after all parameters types definitions. */
+            DataType *callbackParamType = functionType->getReturnStructMemberType()->getDataType();
+            for (StructMember *callbackParam : functionType->getParameters().getMembers())
+            {
+                DataType *callbackParamDataType = callbackParam->getDataType();
+                if (!callbackParamType || callbackParamDataType->getFirstLine() > callbackParamType->getFirstLine())
+                {
+                    callbackParamType = callbackParamDataType;
+                }
+            }
+            if (!callbackParamType || !callbackParamType->isAlias())
+            {
+                /* order isn't important */
+                aliasTypeVector.insert(aliasTypeVector.begin() + i++, a);
+            }
+            else
+            {
+                /* skip structure, unions and functions type definitions */
+                for (unsigned int aliasTypesIt = i; aliasTypesIt < aliasTypeVector.size(); ++aliasTypesIt)
+                {
+                    if (callbackParamType == aliasTypeVector[aliasTypesIt])
+                    {
+                        // Add aliases in IDL declaration order.
+                        unsigned int nextIt = aliasTypesIt + 1;
+                        while (nextIt < aliasTypeVector.size())
+                        {
+                            AliasType *nextAlias = dynamic_cast<AliasType *>(aliasTypeVector[nextIt]);
+                            assert(nextAlias);
+                            if (nextAlias->getElementType()->isFunction())
+                            {
+                                ++nextIt;
+                            }
+                            else
+                            {
+                                break;
+                            }
+                        }
+
+                        aliasTypeVector.insert(aliasTypeVector.begin() + nextIt, a);
+                        break;
+                    }
+                }
+            }
+        }
+
+        /* Table template data. */
+        data_list callbacks;
+        for (Function *fun : functionType->getCallbackFuns())
+        {
+            data_map callbacksInfo;
+            callbacksInfo["name"] = fun->getName();
+            callbacks.push_back(callbacksInfo);
+        }
+        functionInfo["callbacks"] = callbacks;
+        /* Function type name. */
+        functionInfo["name"] = functionType->getName();
+        functions.push_back(functionInfo);
+    }
+    m_templateData["functions"] = functions;
+
+    for (auto it : aliasTypeVector)
+    {
+        AliasType *aliasType = dynamic_cast<AliasType *>(it);
+        assert(aliasType);
+        if (!findAnnotation(aliasType, EXTERNAL_ANNOTATION))
+        {
+            Log::info("%d: ", n);
+            data_map aliasInfo;
+            DataType *elementDataType = aliasType->getElementType();
+            setTemplateComments(aliasType, aliasInfo);
+
+            if (elementDataType->getName() != "")
+            {
+                string realType;
+                if (elementDataType->isFunction())
+                {
+                    realType = getOutputName(aliasType);
+                    aliasInfo["name"] = elementDataType->getName();
+                }
+                else
+                {
+                    realType = getTypenameName(elementDataType, getOutputName(aliasType));
+                    aliasInfo["name"] = getOutputName(aliasType);
+                }
+
+                Log::info("%s\n", realType.c_str());
+
+                /* For case typedef struct/union */
+                if (elementDataType->getName() == aliasType->getName() ||
+                    getOutputName(elementDataType, false) == aliasType->getName())
+                {
+                    if (elementDataType->isStruct())
+                    {
+                        realType = "struct " + realType;
+                    }
+                    else
+                    {
+                        realType = "union " + realType;
+                    }
+                }
+
+                aliasInfo["typenameName"] = realType;
+            }
+            else
+            {
+                aliasInfo["typenameName"] = "";
+                aliasInfo["unnamedName"] = getOutputName(aliasType);
+                switch (elementDataType->getDataType())
+                {
+                    case DataType::kStructType: {
+                        StructType *structType = dynamic_cast<StructType *>(elementDataType);
+                        assert(structType);
+                        aliasInfo["unnamed"] = getStructDefinitionTemplateData(
+                            nullptr, structType, getStructDeclarationTemplateData(structType));
+                        aliasInfo["unnamedType"] = "struct";
+                        break;
+                    }
+                    case DataType::kEnumType: {
+                        EnumType *enumType = dynamic_cast<EnumType *>(elementDataType);
+                        assert(enumType);
+                        aliasInfo["unnamed"] = getEnumTemplateData(enumType);
+                        aliasInfo["unnamedType"] = "enum";
+                        break;
+                    }
+                    default:
+                        throw internal_error("Only structs or enums are allowed as unnamed types.");
+                }
+            }
+            aliases.push_back(aliasInfo);
+            ++n;
+        }
+    }
+    m_templateData["aliases"] = aliases;
+}
+
+AliasType *CPPGenerator::getAliasType(DataType *dataType)
+{
+    for (auto it : m_globals->getSymbolsOfType(DataType::kAliasTypeSymbol))
+    {
+        AliasType *aliasType = dynamic_cast<AliasType *>(it);
+        assert(aliasType);
+        DataType *elementType = aliasType->getElementType();
+        if (elementType == dataType || aliasType == dataType)
+        {
+            return aliasType;
+        }
+    }
+    return nullptr;
+}
+
+string CPPGenerator::getAliasName(DataType *dataType)
+{
+    AliasType *aliasType = getAliasType(dataType);
+    return (aliasType != nullptr) ? getOutputName(aliasType) : "";
+}
+
+void CPPGenerator::makeSymbolsDeclarationTemplateData()
+{
+    Log::info("Symbols templates:\n");
+
+    for (auto it = m_globals->begin(); it != m_globals->end(); ++it)
+    {
+        data_map info;
+
+        switch ((*it)->getSymbolType())
+        {
+            case DataType::kStructTypeSymbol: {
+                StructType *structType = dynamic_cast<StructType *>(*it);
+                assert(structType);
+
+                info = getStructDeclarationTemplateData(structType);
+
+                Log::info("%s\n", structType->getDescription().c_str());
+                m_symbolsTemplate.push_back(info);
+                break;
+            }
+
+            case DataType::kUnionTypeSymbol: {
+                UnionType *unionType = dynamic_cast<UnionType *>(*it);
+                assert(unionType);
+
+                info = getUnionDeclarationTemplateData(unionType);
+
+                Log::info("%s\n", unionType->getDescription().c_str());
+                m_symbolsTemplate.push_back(info);
+                break;
+            }
+
+            default:
+                break;
+        }
+    }
+
+    // header should have all data type defines
+    m_templateData["symbols"] = m_symbolsTemplate;
+}
+
+data_map CPPGenerator::getSymbolTemplateByName(const string &name)
+{
+    for (data_ptr symbol : m_symbolsTemplate)
+    {
+        if (symbol->getmap()["name"]->getvalue() == name)
+        {
+            return symbol->getmap();
+        }
+    }
+
+    data_map empty;
+    return empty;
+}
+
+data_map CPPGenerator::makeGroupSymbolsTemplateData(Group *group)
+{
+    data_map symbolsTemplate;
+    set<string> names;
+
+    data_list symbolsToClient;
+    data_list symbolsToServer;
+    data_list symbolsServerFree;
+
+    Log::info("Group symbols:\n");
+
+    for (Symbol *symbol : group->getSymbols())
+    {
+        data_map info;
+        const set<_param_direction> dirs = group->getSymbolDirections(symbol);
+        if (dirs.size())
+        {
+            switch (symbol->getSymbolType())
+            {
+                case DataType::kStructTypeSymbol: {
+                    StructType *structType = dynamic_cast<StructType *>(symbol);
+                    assert(structType);
+
+                    Log::info("%s\n", structType->getDescription().c_str());
+
+                    string name = (structType->getName() != "") ? getOutputName(structType) : getAliasName(structType);
+
+                    // check if template for this structure has not already been generated
+                    if (names.find(name) == names.end())
+                    {
+                        // get struct declaration info
+                        info = getSymbolTemplateByName(name);
+                        if (info.empty())
+                        {
+                            break;
+                        }
+
+                        // get struct definition info
+                        info = getStructDefinitionTemplateData(group, structType, info);
+
+                        // set symbol data to client or server according to its directions
+                        setSymbolDataToSide(structType, dirs, symbolsToClient, symbolsToServer, info);
+
+                        // struct needs to be freed?
+                        set<DataType *> loopDetection;
+                        if (structType->containStringMember() || structType->containListMember() ||
+                            containsByrefParamToFree(structType, loopDetection))
+                        {
+                            symbolsServerFree.push_back(info);
+                        }
+
+                        names.insert(name);
+                    }
+                    break;
+                }
+                case DataType::kUnionTypeSymbol: {
+                    UnionType *unionType = dynamic_cast<UnionType *>(symbol);
+                    assert(unionType);
+
+                    Log::info("%s\n", unionType->getDescription().c_str());
+
+                    string name = getOutputName(unionType);
+
+                    // check if template for this union has not already been generated
+                    if (names.find(name) == names.end())
+                    {
+                        info = getSymbolTemplateByName(name);
+                        if (info.empty())
+                        {
+                            break;
+                        }
+
+                        // get union info
+                        data_map unionBaseInfo = getUnionDeclarationTemplateData(unionType);
+                        bool needUnionsServerFree = false;
+                        info = getUnionDefinitionTemplateData(group, unionType, unionBaseInfo, needUnionsServerFree);
+
+                        // set symbol data to client or server according to its directions
+                        setSymbolDataToSide(unionType, dirs, symbolsToClient, symbolsToServer, info);
+
+                        // free unions on server side.
+                        if (needUnionsServerFree)
+                        {
+                            symbolsServerFree.push_back(info);
+                        }
+
+                        names.insert(name);
+                    }
+                    break;
+                }
+                default:
+                    break;
+            }
+        }
+    }
+
+    symbolsTemplate["symbolsToClient"] = symbolsToClient;
+    symbolsTemplate["symbolsToServer"] = symbolsToServer;
+    symbolsTemplate["symbolsServerFree"] = symbolsServerFree;
+
+    return symbolsTemplate;
+}
+
+data_list CPPGenerator::makeGroupCallbacksTemplateData(Group *group)
+{
+    data_list functionTypes;
+    std::map<FunctionType *, int> functionTypeMap;
+
+    // need go trough functions instead of group symbols.
+    for (Interface *interface : group->getInterfaces())
+    {
+        for (Function *function : interface->getFunctions())
+        {
+            FunctionType *functionType = function->getFunctionType();
+            if (functionType)
+            {
+                bool isPresent = (functionTypeMap.find(functionType) != functionTypeMap.end());
+                if (isPresent)
+                {
+                    ++functionTypeMap[functionType];
+                }
+                else
+                {
+                    functionTypeMap[functionType] = 1;
+                }
+            }
+        }
+    }
+
+    for (std::map<FunctionType *, int>::iterator it = functionTypeMap.begin(); it != functionTypeMap.end(); ++it)
+    {
+        if (it->second > 1)
+        {
+            functionTypes.push_back(getFunctionTypeTemplateData(group, it->first));
+        }
+    }
+
+    return functionTypes;
+}
+
+data_map CPPGenerator::getStructDeclarationTemplateData(StructType *structType)
+{
+    data_map info;
+    info["name"] = (structType->getName() != "" ? getOutputName(structType) : getAliasName(structType));
+    info["type"] = "struct";
+
+    setTemplateComments(structType, info);
+
+    // external annotation
+    if (findAnnotation(structType, EXTERNAL_ANNOTATION))
+    {
+        info["isExternal"] = true;
+    }
+    else
+    {
+        info["isExternal"] = false;
+        m_templateData["nonExternalStructUnion"] = true;
+    }
+
+    data_list members;
+    for (auto member : structType->getMembers())
+    {
+        data_map member_info;
+
+        string memberName = getOutputName(member);
+        member_info["name"] = memberName;
+
+        DataType *trueDataType = member->getDataType()->getTrueDataType();
+        // Check if member is byRef type. Add "*" for type and allocate space for data on server side.
+        if (member->isByref() &&
+            (trueDataType->isStruct() || trueDataType->isUnion() || trueDataType->isScalar() || trueDataType->isEnum()))
+        {
+            memberName = "*" + memberName;
+        }
+        member_info["memberDeclaration"] = getTypenameName(member->getDataType(), memberName) + ";";
+
+        member_info["elementsCount"] = "";
+        if (isBinaryStruct(structType))
+        {
+            member_info["elementsCount"] = "uint32_t dataLength;";
+        }
+        else if (isListStruct(structType))
+        {
+            member_info["elementsCount"] = "uint32_t elementsCount;";
+        }
+
+        setTemplateComments(member, member_info);
+
+        members.push_back(member_info);
+    }
+    info["members"] = members;
+
+    return info;
+}
+
+data_map CPPGenerator::getStructDefinitionTemplateData(Group *group, StructType *structType, data_map structInfo)
+{
+    // reset list numbering.
+    listCounter = 0;
+
+    structInfo["hasNullableMember"] = false;
+    structInfo["needTempVariable"] = false;
+    structInfo["genStructWrapperF"] = !isBinaryStruct(structType);
+    structInfo["noSharedMem"] = (findAnnotation(structType, NO_SHARED_ANNOTATION) != nullptr);
+
+    setTemplateComments(structType, structInfo);
+
+    // set struct members template data
+    data_list members;
+    assert(dynamic_cast<DataList *>(structInfo["members"].get().get()));
+    data_list baseMembers = dynamic_cast<DataList *>(structInfo["members"].get().get())->getlist();
+    data_list membersToFree;
+
+    for (StructMember *member : structType->getMembers())
+    {
+        data_map member_info;
+
+        // find base member template
+        for (data_ptr mt : baseMembers)
+        {
+            if (mt->getmap()["name"]->getvalue() == getOutputName(member))
+            {
+                member_info = mt->getmap();
+                break;
+            }
+        }
+        if (member_info.empty())
+        {
+            Log::info("Could not find base member template for member '%s'\n", member->getName().c_str());
+            continue;
+        }
+
+        // member data type
+        DataType *dataType = member->getDataType();
+        DataType *trueDataType = member->getDataType()->getTrueDataType();
+        string memberName = getOutputName(member);
+
+        bool isPtrType = (member->isByref() || trueDataType->isBinary() || trueDataType->isString() ||
+                          trueDataType->isList() || trueDataType->isFunction());
+        // When forward declaration is used member should be present as pointer to data.
+        if (!isPtrType && isMemberDataTypeUsingForwardDeclaration(structType, dataType))
+        {
+            throw syntax_error(
+                format_string("line %d: Struct member shall use byref option. Member is using forward declared type.",
+                              member->getFirstLine())
+                    .c_str());
+        }
+        // Handle nullable annotation
+        bool isNullable =
+            ((findAnnotation(member, NULLABLE_ANNOTATION) != nullptr) &&
+             (isPtrType || (trueDataType->isStruct() && (isListStruct(dynamic_cast<StructType *>(trueDataType)) ||
+                                                         (isBinaryStruct(dynamic_cast<StructType *>(trueDataType)))))));
+        member_info["isNullable"] = isNullable;
+        member_info["structElements"] = "";
+        member_info["structElementsCount"] = "";
+        member_info["noSharedMem"] = (findAnnotation(member, NO_SHARED_ANNOTATION) != nullptr);
+
+        if (isNullable)
+        {
+            // hasNullableMember must be true if there at least one struct member with nullable annotation
+            structInfo["hasNullableMember"] = true;
+
+            // Set a flag on the struct indicating there are nullable members, but only
+            // set it to true
+            if (dataType->isStruct() && (isListStruct(dynamic_cast<StructType *>(dataType)) ||
+                                         isBinaryStruct(dynamic_cast<StructType *>(dataType))))
+            {
+                if (isListStruct(dynamic_cast<StructType *>(dataType)))
+                {
+                    member_info["structElements"] = ".elements";
+                    member_info["structElementsCount"] = ".elementsCount";
+                }
+                else if (isBinaryStruct(dynamic_cast<StructType *>(dataType)))
+                {
+                    member_info["structElements"] = ".data";
+                    member_info["structElementsCount"] = ".dataLength";
+                }
+            }
+        }
+
+        // Skip data serialization for variables placed as @length value for lists.
+        // Skip data serialization for variables used as discriminator for unions.
+        // These prevent to serialized data twice.
+        StructMember *referencedFrom = findParamReferencedFrom(structType->getMembers(), member->getName());
+        if (referencedFrom && !findAnnotation(member, SHARED_ANNOTATION))
+        {
+            Log::debug("Skipping EncodeDecode member '%s' with paramType '%s' (it's serialized with member '%s').\n",
+                       memberName.c_str(), dataType->getName().c_str(), referencedFrom->getName().c_str());
+            member_info["coderCall"] = "";
+            member_info["serializedViaMember"] = getOutputName(referencedFrom);
+        }
+        else
+        {
+            Log::debug("Calling EncodeDecode member '%s' with paramType '%s'.\n", memberName.c_str(),
+                       dataType->getName().c_str());
+
+            // Subtemplate setup for read/write struct calls
+            bool needTempVariable = false;
+            member_info["coderCall"] = getEncodeDecodeCall("data->" + memberName, group, dataType, structType, true,
+                                                           member, needTempVariable, false);
+
+            if (needTempVariable)
+            {
+                structInfo["needTempVariable"] = true;
+            }
+
+            member_info["serializedViaMember"] = "";
+        }
+
+        members.push_back(member_info);
+        if (member->isByref() || isNeedCallFree(dataType))
+        {
+            membersToFree.push_back(member_info);
+        }
+    }
+
+    structInfo["members"] = members; // overwrite member's declaration with whole definition
+    structInfo["membersToFree"] = membersToFree;
+
+    return structInfo;
+}
+
+data_map CPPGenerator::getUnionDeclarationTemplateData(UnionType *unionType)
+{
+    data_map info;
+    info["name"] = getOutputName(unionType);
+    info["type"] = "union";
+
+    setTemplateComments(unionType, info);
+    // external annotation
+    if (findAnnotation(unionType, EXTERNAL_ANNOTATION))
+    {
+        info["isExternal"] = true;
+    }
+    else
+    {
+        info["isExternal"] = false;
+        m_templateData["nonExternalStructUnion"] = true;
+    }
+
+    setUnionMembersTemplateData(unionType, info);
+
+    return info;
+}
+
+data_map CPPGenerator::getUnionDefinitionTemplateData(Group *group, UnionType *unionType, data_map &unionInfo,
+                                                    bool &needUnionsServerFree)
+{
+    (void)group;
+    bool needTempVariable = false;
+    unionInfo["coderCall"] =
+        getEncodeDecodeCall("data->", nullptr, unionType, nullptr, true, nullptr, needTempVariable, false);
+    unionInfo["needTempVariable"] = needTempVariable;
+
+    unionInfo["noSharedMem"] = (findAnnotation(unionType, NO_SHARED_ANNOTATION) != nullptr);
+
+    // free unions on server side.
+    for (auto unionCase : unionType->getUniqueCases())
+    {
+        if (!unionCase->caseMemberIsVoid())
+        {
+            for (auto memberName : unionCase->getMemberDeclarationNames())
+            {
+                StructMember *unionMember = unionCase->getUnionMemberDeclaration(memberName);
+                DataType *trueMemberDataType = unionMember->getDataType()->getTrueDataType();
+                if (unionMember->isByref() || trueMemberDataType->isList() || trueMemberDataType->isBinary() ||
+                    trueMemberDataType->isString())
+                {
+                    needUnionsServerFree = true;
+                    break;
+                }
+                else if (trueMemberDataType->isStruct())
+                {
+                    StructType *structType = dynamic_cast<StructType *>(trueMemberDataType);
+                    assert(structType);
+                    set<DataType *> loopDetection;
+                    if (structType->containStringMember() || structType->containListMember() ||
+                        containsByrefParamToFree(structType, loopDetection))
+                    {
+                        needUnionsServerFree = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (needUnionsServerFree)
+        {
+            break;
+        }
+    }
+    return unionInfo;
+}
+
+void CPPGenerator::setUnionMembersTemplateData(UnionType *unionType, data_map &unionInfo)
+{
+    data_list unionCasesList;
+    for (auto unionCase : unionType->getUniqueCases())
+    {
+        if (!unionCase->caseMemberIsVoid())
+        {
+            data_list unionCaseList;
+            for (auto memberName : unionCase->getMemberDeclarationNames())
+            {
+                data_map unionMemberMap;
+                StructMember *unionMember = unionCase->getUnionMemberDeclaration(memberName);
+                string unionMemberName = getOutputName(unionMember);
+                DataType *unionMemberType = unionMember->getDataType()->getTrueDataType();
+
+                // Check if member is byRef type. Add "*" for type and allocate space for data on server side.
+                if (unionMember->isByref() && (unionMemberType->isStruct() || unionMemberType->isUnion() ||
+                                               unionMemberType->isScalar() || unionMemberType->isEnum()))
+                {
+                    unionMemberName = "*" + unionMemberName;
+                }
+
+                unionMemberMap["typenameName"] = getTypenameName(unionMember->getDataType(), unionMemberName);
+                unionCaseList.push_back(unionMemberMap);
+            }
+            unionCasesList.push_back(unionCaseList);
+        }
+    }
+    unionInfo["unionCases"] = unionCasesList;
+}
+
+string CPPGenerator::getUnionMembersData(UnionType *unionType, string indent)
+{
+    // Data are parsed from templates data and returned as string.
+    data_map data;
+    data["unionMembersDeclaration"] = m_templateData["unionMembersDeclaration"];
+    setUnionMembersTemplateData(unionType, data);
+    data["info"] = data;
+
+    // there is always one indent "...."
+    indent += "    ";
+
+    // code to parse
+    string command = "{$addIndent('" + indent + "', unionMembersDeclaration(info))}";
+
+    // parse
+    return parse(command, data);
+}
+
+void CPPGenerator::setTemplateComments(Symbol *symbol, data_map &symbolInfo)
+{
+    symbolInfo["mlComment"] = symbol->getMlComment();
+    symbolInfo["ilComment"] = symbol->getIlComment();
+}
+bool CPPGenerator::isServerNullParam(StructMember *param)
+{
+    DataType *paramTrueDataType = param->getDataType()->getTrueDataType();
+    return (!paramTrueDataType->isScalar() && !paramTrueDataType->isEnum() && !paramTrueDataType->isArray());
+}
+
+bool CPPGenerator::isPointerParam(StructMember *param)
+{
+    DataType *paramTrueDataType = param->getDataType()->getTrueDataType();
+    return (isServerNullParam(param) ||
+            ((paramTrueDataType->isScalar() || paramTrueDataType->isEnum()) && param->getDirection() != kInDirection));
+}
+
+bool CPPGenerator::isNullableParam(StructMember *param)
+{
+    return (findAnnotation(param, NULLABLE_ANNOTATION) && isPointerParam(param));
+}
+
+data_map CPPGenerator::getFunctionBaseTemplateData(Group *group, FunctionBase *fn)
+{
+    data_map info;
+    Symbol *fnSymbol = dynamic_cast<Symbol *>(fn);
+
+    // reset list numbering.
+    listCounter = 0;
+
+    info["isOneway"] = fn->isOneway();
+    info["isReturnValue"] = !fn->isOneway();
+    info["isSendValue"] = false;
+    setTemplateComments(fnSymbol, info);
+    info["needTempVariableServer"] = false;
+    info["needTempVariableClient"] = false;
+    info["needNullVariableOnServer"] = false;
+
+    /* Is function declared as external? */
+    info["isNonExternalFunction"] = !findAnnotation(fnSymbol, EXTERNAL_ANNOTATION);
+
+    // Get return value info
+    data_map returnInfo;
+    returnInfo["type"] = getTypeInfo(fn->getReturnType(), true);
+    StructMember *structMember = fn->getReturnStructMemberType();
+    DataType *dataType = fn->getReturnType();
+    DataType *trueDataType = dataType->getTrueDataType();
+    if (!trueDataType->isVoid())
+    {
+        string result = "result";
+        bool needTempVariable = false;
+        setCallingFreeFunctions(structMember, returnInfo, true);
+        string extraPointer = getExtraPointerInReturn(dataType);
+        string resultVariable = extraPointer + returnSpaceWhenNotEmpty(extraPointer) + result;
+        if (findAnnotation(structMember, NULLABLE_ANNOTATION) == nullptr)
+        {
+            returnInfo["isNullable"] = false;
+            returnInfo["nullableName"] = "";
+        }
+        else
+        {
+            returnInfo["isNullable"] = true;
+            returnInfo["nullableName"] = result;
+        }
+        bool isShared = (findAnnotation(structMember, SHARED_ANNOTATION) != nullptr);
+        if (!isShared)
+        {
+            returnInfo["firstAlloc"] = firstAllocOnReturnWhenIsNeed(result, dataType);
+            result = extraPointer + result;
+        }
+        else
+        {
+            returnInfo["firstAlloc"] = "";
+        }
+
+        // due to compatibility with function parameters.
+        returnInfo["lengthName"] = "";
+        returnInfo["nullVariable"] = "";
+
+        returnInfo["direction"] = getDirection(kReturn);
+        returnInfo["coderCall"] =
+            getEncodeDecodeCall(result, group, dataType, nullptr, false, structMember, needTempVariable, true);
+        returnInfo["shared"] = isShared;
+        resultVariable = getTypenameName(dataType, resultVariable);
+        info["needTempVariableClient"] = needTempVariable;
+        returnInfo["resultVariable"] = resultVariable;
+        returnInfo["errorReturnValue"] = getErrorReturnValue(fn);
+        returnInfo["isNullReturnType"] = (!trueDataType->isScalar() && !trueDataType->isEnum());
+    }
+    info["returnValue"] = returnInfo;
+
+    // get function parameter info
+    auto fnParams = fn->getParameters().getMembers();
+    data_list params;
+    data_list paramsToFree;
+    data_list paramsToClient;
+    data_list paramsToServer;
+    for (StructMember *param : fnParams)
+    {
+        data_map paramInfo;
+        bool needTempVariable = false;
+        DataType *paramType = param->getDataType();
+        DataType *paramTrueType = paramType->getTrueDataType();
+        string name = getOutputName(param);
+
+        // Init parameters to NULL on server side
+        bool isServerNull = isServerNullParam(param);
+        paramInfo["isNullParam"] = isServerNull;
+
+        // Handle nullable annotation.
+        bool isNullable = isNullableParam(param);
+        paramInfo["isNullable"] = isNullable;
+
+        // Serialize when list/union is nullable
+        paramInfo["referencedName"] = "";
+
+        // Skip data serialization for variables placed as @length value for lists.
+        // Skip data serialization for variables used as discriminator for unions.
+        // These prevent to serialized data twice.
+        StructMember *referencedFrom = findParamReferencedFrom(fnParams, param->getName());
+        if (referencedFrom != nullptr && findAnnotation(referencedFrom, SHARED_ANNOTATION) == nullptr)
+        {
+            bool isNullableReferenced = isNullableParam(referencedFrom);
+            if (isNullable && !isNullableReferenced)
+            {
+                Log::error(
+                    "line %d: Param1 '%s' is serialized through param2 '%s'. Annotation @nullable can be applied for "
+                    "param1 only when same annotation is applied for param2.\n",
+                    param->getFirstLine(), param->getName().c_str(), referencedFrom->getName().c_str());
+                paramInfo["isNullable"] = false;
+            }
+
+            // Serialize when list/union is nullable
+            if (isNullableReferenced)
+            {
+                paramInfo["referencedName"] = getOutputName(referencedFrom);
+            }
+
+            // Directions in which list/union is serializing reference
+            if (referencedFrom->getDirection() == param->getDirection())
+            {
+                paramInfo["serializedDirection"] = getDirection(kInoutDirection);
+            }
+            else
+            {
+                paramInfo["serializedDirection"] = getDirection(referencedFrom->getDirection());
+            }
+        }
+        else
+        {
+            paramInfo["serializedDirection"] = "";
+        }
+
+        // data == NULL also when length variable == NULL
+        paramInfo["lengthName"] = "";
+
+        // due to compatibility with return data.
+        paramInfo["firstAlloc"] = "";
+
+        // Need extra variable to handle nullable for enums and scalar types on server side.
+        paramInfo["nullVariable"] = "";
+        if (isNullable)
+        {
+            // Out @nullable param need send @nullable information
+            info["isSendValue"] = true;
+
+            // data == NULL also when length variable == NULL
+            string lengthParam = getAnnStringValue(param, LENGTH_ANNOTATION);
+            if (!lengthParam.empty())
+            {
+                Symbol *symbol = fn->getParameters().getScope().getSymbol(lengthParam, false);
+                if (symbol != nullptr)
+                {
+                    StructMember *st = dynamic_cast<StructMember *>(symbol);
+                    assert(st);
+                    if (isNullableParam(st))
+                    {
+                        paramInfo["lengthName"] = getOutputName(symbol);
+                    }
+                }
+            }
+
+            // Special case when scalar variables are @nullable
+            string nullableName = getOutputName(param);
+            paramInfo["nullableName"] = nullableName;
+            if (paramTrueType->isScalar() || paramTrueType->isEnum())
+            {
+                string nullVariable = "_" + nullableName;
+                paramInfo["nullVariable"] = getTypenameName(paramTrueType, "*_" + nullableName);
+            }
+
+            // Set flags to indicate whether a local isNull variable is needed on the
+            // server and client sides.
+            //
+            // If needNullVariableX is true, we don't want to overwrite it to false
+            // if a later parameter is not nullable. So, we will only try to set it
+            // if it is not true. Once the variable's value is true, we know we need
+            // a null variable at least once.
+            info["needNullVariableOnServer"] = true;
+        }
+
+        // Check if max_length annotation belongs to "in" param
+        // TODO: Should be global, also for PythonGenerator
+        if (paramTrueType->isList() || paramTrueType->isString())
+        {
+            string maxLengthName = getAnnStringValue(param, MAX_LENGTH_ANNOTATION);
+            if (!maxLengthName.empty())
+            {
+                Symbol *symbol = fn->getParameters().getScope().getSymbol(maxLengthName, false);
+                if (symbol)
+                {
+                    StructMember *symbolStructMember = dynamic_cast<StructMember *>(symbol);
+                    assert(symbolStructMember);
+                    if (symbolStructMember->getDirection() != kInDirection)
+                    {
+                        throw semantic_error(
+                            format_string("line %d, ref %d: The parameter named by a max_length annotation must be "
+                                          "'in' direction type.",
+                                          param->getLocation().m_firstLine, structMember->getLocation().m_firstLine));
+                    }
+                }
+            }
+        }
+
+        paramInfo["mallocServer"] = firstAllocOnServerWhenIsNeed(name, param);
+        setCallingFreeFunctions(param, paramInfo, false);
+
+        // Use shared memory feature instead of serializing/deserializing data.
+        bool isShared = (isPointerParam(param) && findAnnotation(param, SHARED_ANNOTATION) != nullptr);
+        paramInfo["shared"] = isShared;
+        string encodeDecodeName;
+        if (isShared)
+        {
+            encodeDecodeName = name;
+            if (!paramTrueType->isList())
+            {
+                name = "*" + name;
+            }
+        }
+        else
+        {
+            encodeDecodeName = name = getExtraDirectionPointer(param) + name;
+        }
+
+        paramInfo["variable"] = getTypenameName(paramType, name);
+        paramInfo["name"] = name;
+
+        Log::debug("Calling EncodeDecode param %s with paramType %s.\n", param->getName().c_str(),
+                   paramType->getName().c_str());
+        paramInfo["coderCall"] = getEncodeDecodeCall(encodeDecodeName, group, paramType, &fn->getParameters(), false,
+                                                     param, needTempVariable, true);
+
+        // set parameter direction
+        paramInfo["direction"] = getDirection(param->getDirection());
+
+        setSymbolDataToSide(param, group->getSymbolDirections(param), paramsToClient, paramsToServer, paramInfo);
+
+        if (needTempVariable && param->getDirection() != kInDirection)
+        {
+            info["needTempVariableClient"] = true;
+        }
+        if (needTempVariable && (param->getDirection() == kInDirection || param->getDirection() == kInoutDirection))
+        {
+            info["needTempVariableServer"] = true;
+        }
+        params.push_back(paramInfo);
+
+        // Generating top of freeing functions in generated output.
+        bool l_generateServerFunctionParamFreeFunctions = (!isShared && generateServerFreeFunctions(param));
+        if (l_generateServerFunctionParamFreeFunctions &&
+            (isNeedCallFree(paramType) || paramInfo["firstFreeingCall1"]->getmap()["freeName"]->getvalue() != ""))
+        {
+            paramsToFree.push_back(paramInfo);
+        }
+    }
+    if (paramsToClient.size() > 0)
+    {
+        info["isReturnValue"] = true;
+    }
+    if (paramsToServer.size() > 0)
+    {
+        info["isSendValue"] = true;
+    }
+    info["parameters"] = make_data(params);
+    info["paramsToFree"] = paramsToFree;
+    info["parametersToClient"] = paramsToClient;
+    info["parametersToServer"] = paramsToServer;
+
+    return info;
+}
+
+data_map CPPGenerator::getFunctionTemplateData(Group *group, Function *fn)
+{
+    data_map info;
+
+    info = getFunctionBaseTemplateData(group, fn);
+
+    // Ignore function shim code. Will be serialized through common function.
+    bool useCommonFunction = false;
+    if (fn->getFunctionType())
+    {
+        int similarFunctions = 0;
+        for (Interface *interface : group->getInterfaces())
+        {
+            for (Function *function : interface->getFunctions())
+            {
+                if (fn->getFunctionType() == function->getFunctionType())
+                {
+                    ++similarFunctions;
+                }
+            }
+        }
+
+        if (similarFunctions > 1)
+        {
+            useCommonFunction = true;
+        }
+    }
+
+    if (useCommonFunction)
+    {
+        std::string callbackFName = getOutputName(fn->getFunctionType());
+        if (!group->getName().empty())
+        {
+            callbackFName += "_" + group->getName();
+        }
+        info["isCallback"] = true;
+        info["callbackFName"] = callbackFName;
+        info["serviceId"] = fn->getInterface()->getUniqueId();
+    }
+    else
+    {
+        info["isCallback"] = false;
+        string serverProto = getFunctionServerCall(fn);
+        info["serverPrototype"] = serverProto;
+        info["serviceId"] = "";
+    }
+
+    string proto = getFunctionPrototype(group, fn);
+    info["prototype"] = proto;
+    info["name"] = getOutputName(fn);
+    info["id"] = fn->getUniqueId();
+
+    return info;
+}
+
+data_map CPPGenerator::getFunctionTypeTemplateData(Group *group, FunctionType *fn)
+{
+    data_map info;
+    std::string name = getOutputName(fn);
+    // group specific common function name
+    if (!group->getName().empty())
+    {
+        name += "_" + group->getName();
+    }
+
+    // set parameters name
+    int j = 0;
+    for (StructMember *structMember : fn->getParameters().getMembers())
+    {
+        if (structMember->getName().empty())
+        {
+            structMember->setName("param" + boost::lexical_cast<std::string>(j++));
+        }
+    }
+
+    string proto = getFunctionPrototype(group, fn, name);
+    info = getFunctionBaseTemplateData(group, fn);
+    info["prototype"] = proto;
+    info["name"] = name;
+
+    data_list functionInfos;
+    for (Function *function : fn->getCallbackFuns())
+    {
+        data_map functionInfo = getFunctionTemplateData(group, function);
+        // set serverPrototype function with parameters of common function.
+        string serverProto = getFunctionServerCall(function, fn);
+        functionInfo["serverPrototype"] = serverProto;
+        functionInfos.push_back(functionInfo);
+    }
+
+    info["functions"] = functionInfos;
+
+    return info;
+}
+
+void CPPGenerator::setSymbolDataToSide(const Symbol *symbolType, const set<_param_direction> directions,
+                                     data_list &toClient, data_list &toServer, data_map &dataMap)
+{
+    _direction direction = kIn;
+    switch (symbolType->getSymbolType())
+    {
+        case Symbol::kStructTypeSymbol:
+        case Symbol::kUnionTypeSymbol:
+        case Symbol::kFunctionTypeSymbol: {
+            bool in = directions.count(kInDirection);
+            bool out = directions.count(kOutDirection);
+            bool inOut = directions.count(kInoutDirection);
+            bool ret = directions.count(kReturn);
+
+            Log::info("Symbol %s has directions: in:%d, out:%d, inOut:%d, ret:%d\n", symbolType->getName().c_str(), in,
+                      out, inOut, ret);
+
+            if (inOut || (in && (ret || out)))
+            {
+                direction = kInOut;
+            }
+            else if (ret || out)
+            {
+                direction = kOut;
+            }
+            else if (!in && !out && !ret && !inOut)
+            {
+                // ToDo: shared pointer.
+                direction = kNone;
+            }
+
+            break;
+        }
+        case Symbol::kStructMemberSymbol: {
+            const StructMember *structMember = dynamic_cast<const StructMember *>(symbolType);
+            assert(structMember);
+            switch (structMember->getDirection())
+            {
+                case kOutDirection:
+                case kInoutDirection: {
+                    direction = kInOut;
+                    break;
+                }
+                case kInDirection: {
+                    direction = kIn;
+                    break;
+                }
+                default: {
+                    throw internal_error("Unsupported direction type of structure member.");
+                }
+            }
+            break;
+        }
+        default: {
+            throw internal_error(format_string("Symbol: %s is not structure or function parameter.",
+                                               symbolType->getDescription().c_str()));
+        }
+    }
+
+    switch (direction)
+    {
+        case kIn: {
+            toServer.push_back(dataMap);
+            break;
+        }
+        case kOut: {
+            toClient.push_back(dataMap);
+            break;
+        }
+        case kInOut: {
+            toServer.push_back(dataMap);
+            toClient.push_back(dataMap);
+            break;
+        }
+        case kNone: // ToDo: shared pointer
+        {
+            break;
+        }
+        default:
+            throw runtime_error("internal error: unexpected parameter direction");
+    }
+}
+
+data_map CPPGenerator::getTypeInfo(DataType *t, bool isFunction)
+{
+    (void)isFunction;
+    data_map info;
+    info["isNotVoid"] = make_data(t->getDataType() != DataType::kVoidType);
+    return info;
+}
+
+string CPPGenerator::getErrorReturnValue(FunctionBase *fn)
+{
+    Symbol *symbol = dynamic_cast<Symbol *>(fn);
+    assert(symbol);
+
+    Value *returnVal = getAnnValue(symbol, ERROR_RETURN_ANNOTATION);
+    DataType *dataType = fn->getReturnType()->getTrueDataType();
+    if (returnVal)
+    {
+        if (returnVal->toString().empty())
+        {
+            throw semantic_error(format_string("Expected value for @%s annotation for function on line %d",
+                                               ERROR_RETURN_ANNOTATION, symbol->getLocation().m_firstLine));
+        }
+        else if (dataType->isString())
+        {
+            return (dataType->isUString() ? "(unsigned char *)" : "(char*)") + returnVal->toString();
+        }
+        else if (dataType->isScalar())
+        {
+            BuiltinType *builtinType = dynamic_cast<BuiltinType *>(dataType);
+            assert(builtinType);
+            if (builtinType->getBuiltinType() == BuiltinType::kBoolType)
+            {
+                IntegerValue *integerValue = dynamic_cast<IntegerValue *>(returnVal);
+                assert(integerValue);
+                return (integerValue->getValue()) ? "true" : "false";
+            }
+        }
+        return returnVal->toString();
+    }
+    else
+    {
+        if (dataType->isScalar())
+        {
+            BuiltinType *builtinType = dynamic_cast<BuiltinType *>(dataType);
+            assert(builtinType);
+            switch (builtinType->getBuiltinType())
+            {
+                case BuiltinType::kBoolType: {
+                    return "false";
+                }
+                case BuiltinType::kUInt8Type: {
+                    return "0xFFU";
+                }
+                case BuiltinType::kUInt16Type: {
+                    return "0xFFFFU";
+                }
+                case BuiltinType::kUInt32Type: {
+                    return "0xFFFFFFFFU";
+                }
+                case BuiltinType::kUInt64Type: {
+                    return "0xFFFFFFFFFFFFFFFFU";
+                }
+                default: {
+                    return "-1";
+                }
+            }
+        }
+        else if (dataType->isEnum())
+        {
+            return "(" + getOutputName(fn->getReturnType()) + ") -1";
+        }
+        else
+        {
+            return "NULL";
+        }
+    }
+}
+
+string CPPGenerator::getFunctionServerCall(Function *fn, FunctionType *functionType)
+{
+    string proto = "";
+    if (!fn->getReturnType()->isVoid())
+    {
+        proto += "result = ";
+    }
+    proto += getOutputName(fn);
+    proto += "(";
+
+    auto params = (functionType) ? functionType->getParameters().getMembers() : fn->getParameters().getMembers();
+
+    if (params.size())
+    {
+        unsigned int n = 0;
+        for (auto it : params)
+        {
+            bool isLast = (n == params.size() - 1);
+            DataType *trueDataType = it->getDataType()->getTrueDataType();
+
+            /* Builtin types and function types. */
+            if (((trueDataType->isScalar()) || trueDataType->isEnum()) && it->getDirection() != kInDirection &&
+                findAnnotation(it, NULLABLE_ANNOTATION))
+            {
+                // On server side is created new variable for handle null : "_" + name
+                proto += "_";
+            }
+            else if ((it->getDirection() != kInDirection) && (((trueDataType->isScalar()) || trueDataType->isEnum()) ||
+                                                              (findAnnotation(it, SHARED_ANNOTATION))))
+
+            {
+                proto += "&";
+            }
+            proto += getOutputName(it);
+
+            if (!isLast)
+            {
+                proto += ", ";
+            }
+            ++n;
+        }
+    }
+    return proto + ");";
+}
+
+string CPPGenerator::getFunctionPrototype(Group *group, FunctionBase *fn, std::string name)
+{
+    DataType *dataTypeReturn = fn->getReturnType();
+    string proto = getExtraPointerInReturn(dataTypeReturn);
+    if (proto == "*")
+    {
+        proto += " ";
+    }
+
+    Symbol *symbol = dynamic_cast<Symbol *>(fn);
+    assert(symbol);
+
+    auto interfaces = group->getInterfaces();
+    const std::string iface_group_name = (group != nullptr) ? interfaces[0]->getName() : "";
+    
+    FunctionType *funType = dynamic_cast<FunctionType *>(fn);
+    if (name.empty())
+    {
+        string functionName = getOutputName(symbol);
+        if (funType) /* Need add '(*name)' for function type definition. */
+        {
+            proto += "(*" + functionName + ")";
+        }
+        else /* Use function name only. */
+        {
+            if (group != nullptr)
+            {
+                proto += iface_group_name + "_client_t";
+                proto += "::";
+            }
+            proto += functionName;
+        }
+    }
+    else
+    {
+        proto += name;
+    }
+
+    proto += "(";
+
+    auto params = fn->getParameters().getMembers();
+    // add interface id and function id parameters for common callbacks shim code function
+    if (!name.empty())
+    {
+        proto += "uint32_t serviceID, uint32_t functionID";
+        if (params.size() > 0)
+        {
+            proto += ", ";
+        }
+    }
+
+    if (params.size())
+    {
+        unsigned int n = 0;
+        for (auto it : params)
+        {
+            bool isLast = (n == params.size() - 1);
+            string paramSignature = getOutputName(it);
+            DataType *dataType = it->getDataType();
+            DataType *trueDataType = dataType->getTrueDataType();
+
+            /* Add '*' to data types. */
+            if (((trueDataType->isBuiltin() || trueDataType->isEnum()) &&
+                 (it->getDirection() != kInDirection && !trueDataType->isString())) ||
+                (trueDataType->isFunction() &&
+                 (it->getDirection() == kOutDirection || it->getDirection() == kInoutDirection)))
+            {
+                paramSignature = "* " + paramSignature;
+            }
+            else
+            {
+                string directionPointer = getExtraDirectionPointer(it);
+                paramSignature = directionPointer + returnSpaceWhenNotEmpty(directionPointer) + paramSignature;
+            }
+            paramSignature = getTypenameName(dataType, paramSignature);
+
+            if (!(m_def->hasProgramSymbol() &&
+                  (findAnnotation(m_def->getProgramSymbol(), NO_CONST_PARAM) ||
+                   ((funType && findAnnotation(funType, NO_CONST_PARAM)) ||
+                    (!funType && findAnnotation(dynamic_cast<Function *>(fn), NO_CONST_PARAM))) ||
+                   findAnnotation(it, NO_CONST_PARAM))))
+            {
+                if ((dataType->isString() || dataType->isFunction() || trueDataType->isStruct() ||
+                     trueDataType->isList() || trueDataType->isArray() || trueDataType->isBinary() ||
+                     trueDataType->isUnion()) &&
+                    it->getDirection() == kInDirection)
+                {
+                    bool pass = true;
+                    if (trueDataType->isArray())
+                    {
+                        ArrayType *arrayType = dynamic_cast<ArrayType *>(trueDataType);
+                        assert(arrayType);
+                        DataType *elementType = arrayType->getElementType()->getTrueDataType();
+                        if (elementType->isArray() || elementType->isString() || elementType->isList() ||
+                            elementType->isBinary())
+                        {
+                            pass = false;
+                        }
+                    }
+                    if (trueDataType->isList())
+                    {
+                        ListType *listType = dynamic_cast<ListType *>(trueDataType);
+                        assert(listType);
+                        DataType *elementType = listType->getElementType()->getTrueDataType();
+                        if (elementType->isArray() || elementType->isString() || elementType->isList() ||
+                            elementType->isBinary())
+                        {
+                            pass = false;
+                        }
+                    }
+                    if (pass)
+                    {
+                        proto += "const ";
+                    }
+                }
+            }
+
+            DataType *trueContainerDataType = dataType->getTrueContainerDataType();
+            if (trueContainerDataType->isStruct())
+            {
+                StructType *structType = dynamic_cast<StructType *>(trueContainerDataType);
+                assert(structType);
+                // Todo: Need check if members are/aren't shared.
+                if (group != nullptr)
+                {
+                    const set<_param_direction> directions = group->getSymbolDirections(structType);
+                    if (!findAnnotation(it, SHARED_ANNOTATION) &&
+                        (directions.count(kInoutDirection) &&
+                         (directions.count(kOutDirection) || directions.count(kReturn))))
+                    {
+                        throw syntax_error(
+                            format_string("line %d: structs, lists, and binary cannot be used as both "
+                                          "inout and out parameters in the same application",
+                                          it->getLocation().m_firstLine));
+                    }
+                }
+            }
+
+            proto += paramSignature;
+            if (!isLast)
+            {
+                proto += ", ";
+            }
+            ++n;
+        }
+    }
+    else
+    {
+        proto += "void";
+    }
+    proto += ")";
+    if (dataTypeReturn->isArray())
+    {
+        proto = "(" + proto + ")";
+    }
+    return getTypenameName(dataTypeReturn, proto); //! return type
+}
+
+string CPPGenerator::generateIncludeGuardName(const string &filename)
+{
+    string guard;
+
+    // strip directory prefixes
+    string fileNoPath = filename;
+    size_t found = filename.find_last_of("/\\");
+    if (found != string::npos)
+    {
+        fileNoPath = filename.substr(found + 1);
+    }
+    // Create include guard macro name.
+    guard = "_";
+    guard += fileNoPath;
+    guard += "_";
+    size_t loc;
+    while ((loc = guard.find_first_not_of(kIdentifierChars)) != guard.npos)
+    {
+        guard.replace(loc, 1, "_");
+    }
+    return guard;
+}
+
+string CPPGenerator::getTypenameName(DataType *t, const string &name)
+{
+    string returnName;
+    switch (t->getDataType())
+    {
+        case DataType::kArrayType: {
+            // Array type requires the array element count to come after the variable/member name.
+            returnName = name;
+            ArrayType *a = dynamic_cast<ArrayType *>(t);
+            assert(a);
+            giveBracesToArrays(returnName);
+            returnName = format_string("%s[%d]", returnName.c_str(), a->getElementCount());
+            returnName = getTypenameName(a->getElementType(), returnName);
+            break;
+        }
+        case DataType::kBuiltinType: {
+            assert(nullptr != dynamic_cast<const BuiltinType *>(t));
+            returnName = getBuiltinTypename(dynamic_cast<const BuiltinType *>(t));
+            if (!(t->isString() && name != "" && name[0] == '*'))
+            {
+                returnName += returnSpaceWhenNotEmpty(name);
+            }
+            returnName += name;
+            break;
+        }
+        case DataType::kListType: {
+            const ListType *a = dynamic_cast<const ListType *>(t);
+            assert(a);
+            returnName = "* " + name;
+            returnName = getTypenameName(a->getElementType(), returnName);
+            break;
+        }
+        case DataType::kUnionType: {
+            UnionType *unionType = dynamic_cast<UnionType *>(t);
+            assert(unionType);
+            if (unionType->isNonEncapsulatedUnion())
+            {
+                returnName = getOutputName(t);
+                returnName += returnSpaceWhenNotEmpty(name) + name;
+            }
+            else
+            {
+                returnName += "union\n    {\n";
+                returnName += getUnionMembersData(unionType, "    ");
+                returnName += "\n    } " + name;
+            }
+            break;
+        }
+        case DataType::kVoidType: {
+            returnName = "void";
+            returnName += returnSpaceWhenNotEmpty(name) + name;
+            break;
+        }
+        case DataType::kAliasType:
+        case DataType::kEnumType:
+        case DataType::kFunctionType:
+        case DataType::kStructType: {
+            returnName = getOutputName(t);
+            returnName += returnSpaceWhenNotEmpty(name) + name;
+            break;
+        }
+        default:
+            throw internal_error(format_string("In getTypenameName: unknown data type: %s value:%d",
+                                               t->getName().c_str(), t->getDataType()));
+    }
+    return returnName;
+}
+
+string CPPGenerator::getBuiltinTypename(const BuiltinType *t)
+{
+    switch (t->getBuiltinType())
+    {
+        case BuiltinType::kBoolType:
+            return "bool";
+        case BuiltinType::kInt8Type:
+            return "int8_t";
+        case BuiltinType::kInt16Type:
+            return "int16_t";
+        case BuiltinType::kInt32Type:
+            return "int32_t";
+        case BuiltinType::kInt64Type:
+            return "int64_t";
+        case BuiltinType::kUInt8Type:
+            return "uint8_t";
+        case BuiltinType::kUInt16Type:
+            return "uint16_t";
+        case BuiltinType::kUInt32Type:
+            return "uint32_t";
+        case BuiltinType::kUInt64Type:
+            return "uint64_t";
+        case BuiltinType::kFloatType:
+            return "float";
+        case BuiltinType::kDoubleType:
+            return "double";
+        case BuiltinType::kStringType:
+            return "char *";
+        case BuiltinType::kUStringType:
+            return "unsigned char*";
+        case BuiltinType::kBinaryType:
+            return "uint8_t *";
+        default:
+            throw internal_error("unknown builtin type");
+    }
+}
+
+void CPPGenerator::getEncodeDecodeBuiltin(Group *group, BuiltinType *t, data_map &templateData, StructType *structType,
+                                        StructMember *structMember, bool isFunctionParam)
+{
+    templateData["decode"] = m_templateData["decodeBuiltinType"];
+    templateData["encode"] = m_templateData["encodeBuiltinType"];
+
+    if (t->isString())
+    {
+        templateData["checkStringNull"] = false;
+        templateData["withoutAlloc"] = ((structMember->getDirection() == kInoutDirection) ||
+                                        (structType && group->getSymbolDirections(structType).count(kInoutDirection))) ?
+                                           true :
+                                           false;
+        if (!isFunctionParam)
+        {
+            templateData["stringAllocSize"] = getOutputName(structMember) + "_len";
+            templateData["stringLocalName"] = getOutputName(structMember);
+        }
+        else
+        {
+            if (!structType)
+            {
+                templateData["stringAllocSize"] = "return_len";
+                templateData["stringLocalName"] = "return";
+            }
+            else
+            {
+                templateData["checkStringNull"] = true;
+                templateData["stringLocalName"] = getOutputName(structMember);
+                templateData["stringAllocSize"] = getAnnStringValue(structMember, MAX_LENGTH_ANNOTATION);
+                if (structMember->getDirection() == kInoutDirection || structMember->getDirection() == kOutDirection)
+                {
+                    templateData["withoutAlloc"] = true;
+                }
+
+                if (templateData["stringAllocSize"]->getvalue() == "")
+                {
+                    templateData["stringAllocSize"] = templateData["stringLocalName"]->getvalue() + "_len";
+                }
+            }
+        }
+        templateData["freeingCall"] = m_templateData["freeData"];
+        // needDealloc(templateData, t, structType, nullptr);
+        templateData["builtinType"] = "kStringType";
+        templateData["builtinTypeName"] = t->isUString() ? "unsigned char*" : "char*";
+    }
+    else
+    {
+        templateData["builtinType"] = "kNumberType";
+    }
+}
+
+data_map CPPGenerator::getEncodeDecodeCall(const string &name, Group *group, DataType *t, StructType *structType,
+                                         bool inDataContainer, StructMember *structMember, bool &needTempVariable,
+                                         bool isFunctionParam)
+{
+    // prepare data for template
+    data_map templateData;
+    string_vector params = string_vector(1, "");
+    templateData["freeingCall"] = make_template("", &params);
+    templateData["inDataContainer"] = inDataContainer;
+    templateData["isElementArrayType"] = false;
+    data_map defMemberAllocation;
+    templateData["memberAllocation"] = defMemberAllocation;
+    // name used for serializing/deserializing current data type.
+    string localName;
+
+    int pos = name.rfind("*");
+    if ((pos == 0 || pos == 1) && (t->getTrueDataType()->isStruct() || t->getTrueDataType()->isUnion()) &&
+        inDataContainer == false)
+    {
+        localName = name.substr(1, name.length());
+    }
+    else
+    {
+        localName = name;
+    }
+
+    templateData["freeName"] = localName;
+
+    /* Check if member should be serialized as shared. */
+    if ((structMember && findAnnotation(structMember, SHARED_ANNOTATION)) ||
+        (structType && findAnnotation(structType, SHARED_ANNOTATION)))
+    {
+        templateData["funcParam"] = (structType) ? true : false;
+        templateData["InoutOutDirection"] = (structMember && (structMember->getDirection() == kOutDirection ||
+                                                              structMember->getDirection() == kInoutDirection)) ?
+                                                true :
+                                                false;
+        templateData["encode"] = m_templateData["encodeSharedType"];
+        templateData["decode"] = m_templateData["decodeSharedType"];
+        templateData["name"] = name;
+        templateData["sharedTypeName"] = t->getName();
+
+        /* If shared member contains non-shared member, it has to be serialized. */
+        templateData["sharedType"] = "";
+        if (t->isStruct() || t->isUnion())
+        {
+            StructType *s = dynamic_cast<StructType *>(t);
+            if (s)
+            {
+                for (StructMember *m : s->getMembers())
+                {
+                    if (findAnnotation(m, NO_SHARED_ANNOTATION))
+                    {
+                        templateData["sharedType"] = "struct";
+                        templateData["dataLiteral"] = (inDataContainer) ? "data->" : "";
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                UnionType *u = dynamic_cast<UnionType *>(t);
+                assert(u);
+                if (u)
+                {
+                    for (StructMember *m : u->getUnionMembers().getMembers())
+                    {
+                        if (findAnnotation(m, NO_SHARED_ANNOTATION))
+                        {
+                            templateData["sharedType"] = "union";
+                            if (setDiscriminatorTemp(u, structType, structMember, isFunctionParam, templateData))
+                            {
+                                needTempVariable = true;
+                            }
+
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        return templateData;
+    }
+
+    // Check if member is byRef type. Add "*" for type and allocate space for data on server side.
+    if (structMember && structMember->isByref() && !isFunctionParam &&
+        (t->isStruct() || t->isUnion() || t->isScalar() || t->isEnum()))
+    {
+        templateData["freeingCall2"] = m_templateData["freeData"];
+        templateData["memberAllocation"] = allocateCall(name, t);
+        localName = "*" + localName;
+    }
+    else
+    {
+        templateData["freeingCall2"] = make_template("", &params);
+    }
+
+    templateData["name"] = localName;
+
+    if (t->isScalar() || t->isEnum())
+    {
+        templateData["pointerScalarTypes"] = false;
+        if (!inDataContainer && structMember && structMember->getDirection() != kInDirection)
+        {
+            DataType *trueDataType = t->getTrueDataType();
+            if (trueDataType->isScalar() || trueDataType->isEnum())
+            {
+                templateData["pointerScalarTypes"] = true;
+            }
+        }
+    }
+
+    switch (t->getDataType())
+    {
+        case DataType::kAliasType: {
+            AliasType *aliasType = dynamic_cast<AliasType *>(t);
+            assert(aliasType);
+            return getEncodeDecodeCall(name, group, aliasType->getElementType(), structType, inDataContainer,
+                                       structMember, needTempVariable, isFunctionParam);
+        }
+        case DataType::kArrayType: {
+            static uint8_t arrayCounter;
+            ArrayType *arrayType = dynamic_cast<ArrayType *>(t);
+            assert(arrayType);
+            DataType *elementType = arrayType->getElementType();
+            DataType *trueElementType = elementType->getTrueDataType();
+
+            string arrayName = name;
+            templateData["decode"] = m_templateData["decodeArrayType"];
+            templateData["encode"] = m_templateData["encodeArrayType"];
+
+            // To improve code serialization/deserialization for scalar types when BasicCodec is used.
+            templateData["builtinTypeName"] =
+                ((m_def->getCodecType() != InterfaceDefinition::kBasicCodec) || trueElementType->isBool()) ?
+                    "" :
+                    getScalarTypename(elementType);
+
+            giveBracesToArrays(arrayName);
+            templateData["forLoopCount"] = format_string("arrayCount%d", arrayCounter);
+            templateData["protoNext"] =
+                getEncodeDecodeCall(format_string("%s[arrayCount%d]", arrayName.c_str(), arrayCounter++), group,
+                                    elementType, structType, true, structMember, needTempVariable, isFunctionParam);
+            templateData["size"] = format_string("%dU", arrayType->getElementCount());
+            templateData["sizeTemp"] = format_string("%dU", arrayType->getElementCount());
+            templateData["isElementArrayType"] = trueElementType->isArray();
+            if (generateServerFreeFunctions(structMember) && isNeedCallFree(t))
+            {
+                templateData["freeingCall"] = m_templateData["freeArray"];
+            }
+            templateData["pointerScalarTypes"] = false; // List is using array codec functions
+            --arrayCounter;
+            break;
+        }
+        case DataType::kBuiltinType: {
+            getEncodeDecodeBuiltin(group, (BuiltinType *)t, templateData, structType, structMember, isFunctionParam);
+            break;
+        }
+        case DataType::kEnumType: {
+            needTempVariable = true;
+            templateData["decode"] = m_templateData["decodeEnumType"];
+            templateData["encode"] = m_templateData["encodeEnumType"];
+            string typeName = getOutputName(t);
+            if (typeName != "")
+            {
+                templateData["enumName"] = typeName;
+            }
+            else
+            {
+                templateData["enumName"] = getAliasName(t);
+            }
+            break;
+        }
+        case DataType::kFunctionType: {
+            FunctionType *funType = dynamic_cast<FunctionType *>(t);
+            assert(funType);
+            const FunctionType::c_function_list_t &callbacks = funType->getCallbackFuns();
+            templateData["callbacksCount"] = callbacks.size();
+            if (callbacks.size() > 1)
+            {
+                templateData["callbacks"] = "_" + funType->getName();
+            }
+            else if (callbacks.size() == 1)
+            {
+                templateData["callbacks"] = callbacks[0]->getName();
+            }
+            else
+            {
+                throw semantic_error(format_string("line %d: Function has function type parameter (callback "
+                                                   "parameter), but in IDL is missing function definition, which can "
+                                                   "be passed there.",
+                                                   structMember->getFirstLine())
+                                         .c_str());
+            }
+            templateData["encode"] = m_templateData["encodeFunctionType"];
+            templateData["decode"] = m_templateData["decodeFunctionType"];
+            break;
+        }
+        case DataType::kListType: {
+            ListType *listType = dynamic_cast<ListType *>(t);
+            assert(listType);
+            DataType *elementType = listType->getElementType();
+            DataType *trueElementType = elementType->getTrueDataType();
+
+            bool isInOut = ((structMember->getDirection() == kInoutDirection) ||
+                            (!isFunctionParam && group->getSymbolDirections(structType).count(kInoutDirection)));
+
+            bool isTopDataType = (isFunctionParam && structMember->getDataType()->getTrueDataType() == t);
+
+            // Because cpptempl don't know do correct complicated conditions like
+            // if(a || (b && c))
+            templateData["useMallocOnClientSide"] = (!isInOut && !isTopDataType);
+
+            templateData["mallocSizeType"] = getTypenameName(elementType, "");
+            templateData["mallocType"] = getTypenameName(elementType, "*");
+            templateData["needFreeingCall"] =
+                (generateServerFreeFunctions(structMember) && isNeedCallFree(elementType));
+
+            // To improve code serialization/deserialization for scalar types when BasicCodec is used.
+            templateData["builtinTypeName"] =
+                ((m_def->getCodecType() != InterfaceDefinition::kBasicCodec) || trueElementType->isBool()) ?
+                    "" :
+                    getScalarTypename(elementType);
+
+            if (generateServerFreeFunctions(structMember))
+            {
+                templateData["freeingCall"] = m_templateData["freeList"];
+            }
+            templateData["decode"] = m_templateData["decodeListType"];
+            templateData["encode"] = m_templateData["encodeListType"];
+
+            string nextName;
+
+            // Size variable should have same prefix as variable name.
+            auto sizePrefix = name.rfind('.');
+            if (sizePrefix == string::npos)
+            {
+                sizePrefix = name.rfind('>');
+            }
+            string size = "";
+            if (sizePrefix != string::npos)
+            {
+                size = name.substr(0, sizePrefix + 1);
+            }
+            templateData["pointerScalarTypes"] = false;
+            templateData["constantVariable"] = false;
+
+            if (listType->hasLengthVariable())
+            {
+                templateData["hasLengthVariable"] = true;
+
+                nextName = format_string("%s[listCount%d]", name.c_str(), listCounter);
+                // needDealloc(templateData, t, nullptr, structMember);
+                // length is global constant. Should be defined in IDL as array[global_constant] @nullable?
+                Symbol *symbol = m_globals->getSymbol(listType->getLengthVariableName());
+                if (symbol)
+                {
+                    ConstType *constType = dynamic_cast<ConstType *>(symbol);
+                    assert(constType);
+                    size = constType->getValue()->toString();
+                    templateData["constantVariable"] = true;
+                }
+                else
+                {
+                    symbol = structType->getScope().getSymbol(listType->getLengthVariableName(), false);
+                    if (!symbol)
+                    {
+                        // it is just number.
+                        templateData["constantVariable"] = true;
+                    }
+
+                    // on client has to be used dereferencing out length variable when writeBinary/list is used.
+                    if (isFunctionParam)
+                    {
+                        if (symbol)
+                        {
+                            StructMember *lengthVariable = dynamic_cast<StructMember *>(symbol);
+                            assert(lengthVariable);
+                            if (lengthVariable->getDirection() != kInDirection)
+                            {
+                                templateData["pointerScalarTypes"] = true;
+                            }
+                        }
+                    }
+                    size += listType->getLengthVariableName();
+                }
+                templateData["sizeTemp"] = string("lengthTemp_") + to_string(listCounter);
+                templateData["dataTemp"] = string("dataTemp_") + to_string(listCounter);
+                string maxSize = getAnnStringValue(structMember, MAX_LENGTH_ANNOTATION);
+                if (maxSize != "")
+                {
+                    // preppend "data->" when maxSize is struct member
+                    if (!isFunctionParam && structType)
+                    {
+                        Symbol *symbolMax = structType->getScope().getSymbol(maxSize, false);
+                        if (symbolMax)
+                        {
+                            maxSize = "data->" + maxSize;
+                        }
+                    }
+                    templateData["maxSize"] = maxSize;
+                }
+                else
+                {
+                    templateData["maxSize"] = templateData["sizeTemp"]->getvalue();
+                }
+                templateData["forLoopCount"] = string("listCount") + to_string(listCounter);
+                templateData["isElementArrayType"] = trueElementType->isArray();
+                ++listCounter;
+            }
+            else
+            {
+                templateData["hasLengthVariable"] = false;
+                if (sizePrefix != string::npos)
+                {
+                    string usedName = name.substr(sizePrefix + 1, name.size() - sizePrefix - 1);
+                    if (usedName == "data")
+                    {
+                        size += "dataLength";
+                    }
+                    else
+                    {
+                        size += "elementsCount";
+                    }
+                    templateData["sizeTemp"] = size;
+                    templateData["dataTemp"] = usedName + "_local";
+                    templateData["maxSize"] = size;
+                }
+                else
+                {
+                    throw internal_error("Unexpected error with List data type.");
+                }
+                // needDealloc(templateData, t, structType, nullptr);
+                nextName = name + "[listCount]";
+                templateData["forLoopCount"] = "listCount";
+            }
+            templateData["size"] = size;
+            templateData["useBinaryCoder"] = isBinaryList(listType);
+            templateData["protoNext"] = getEncodeDecodeCall(nextName, group, elementType, structType, true,
+                                                            structMember, needTempVariable, isFunctionParam);
+            break;
+        }
+        case DataType::kStructType: {
+            // needDealloc(templateData, t, structType, structMember);
+            string typeName = getOutputName(t);
+            if (typeName != "")
+            {
+                templateData["typeName"] = typeName;
+            }
+            else
+            {
+                templateData["typeName"] = getAliasName(t);
+            }
+            templateData["decode"] = m_templateData["decodeStructType"];
+            templateData["encode"] = m_templateData["encodeStructType"];
+
+            if (generateServerFreeFunctions(structMember) && isNeedCallFree(t))
+            {
+                templateData["freeingCall"] = m_templateData["freeStruct"];
+            }
+            break;
+        }
+        case DataType::kUnionType: {
+            UnionType *unionType = dynamic_cast<UnionType *>(t);
+            assert(unionType);
+
+            // need casting discriminator variable?
+            // set discriminator name
+            if (setDiscriminatorTemp(unionType, structType, structMember, isFunctionParam, templateData))
+            {
+                needTempVariable = true;
+            }
+
+            /* NonEncapsulated unions as a function/structure param/member. */
+            if (isFunctionParam || (structType && unionType->isNonEncapsulatedUnion()))
+            {
+                templateData["inDataContainer"] = inDataContainer;
+                templateData["typeName"] = getOutputName(t);
+                templateData["decode"] = m_templateData["decodeUnionParamType"];
+                templateData["encode"] = m_templateData["encodeUnionParamType"];
+                if (generateServerFreeFunctions(structMember) && isNeedCallFree(t))
+                {
+                    templateData["freeingCall"] = m_templateData["freeUnionType"];
+                }
+
+                // inout/out discriminator
+                templateData["discrimPtr"] = false;
+                if (isFunctionParam)
+                {
+                    if (structMember->getDirection() != kInDirection)
+                    {
+                        templateData["discrimPtr"] = true;
+                    }
+                }
+            }
+            else
+            {
+                /* Serialize/deserialize encapsulated and non-encapsulated unions is almost same. */
+                assert(unionType);
+
+                string disriminatorSeparator = "";
+
+                /* Get discriminator separator for encapsulated unions. data->variable_name.case */
+                if (!unionType->isNonEncapsulatedUnion())
+                {
+                    disriminatorSeparator = ".";
+                }
+
+                data_list unionCases;
+                data_list unionCasesToFree;
+                bool needCaseEmptyFreeingCall = false;
+                // call free function for this union, default not call any free function
+                templateData["freeingCall"] = make_template("", &params);
+                for (auto unionCase : unionType->getCases())
+                {
+                    data_map caseData;
+                    caseData["name"] = unionCase->getCaseName();
+                    caseData["value"] = unionCase->getCaseValue();
+                    // if current case need call free function, default false
+                    caseData["needCaseFreeingCall"] = false;
+                    data_list caseMembers;
+                    data_map memberData;
+                    data_map caseMembersFree;
+                    if (unionCase->caseMemberIsVoid())
+                    {
+                        // Create phony encode/decode values for void function,
+                        // since we don't want to generate anything.
+                        data_map coderCalls;
+                        coderCalls["encode"] = make_template("", &params);
+                        coderCalls["decode"] = make_template("", &params);
+                        coderCalls["memberAllocation"] = "";
+                        memberData["coderCall"] = coderCalls;
+
+                        caseMembers.push_back(memberData);
+                    }
+                    else
+                    {
+                        bool casesNeedTempVariable = false;
+                        // For each case member declaration, get its encode and decode data
+                        for (auto caseMemberName : unionCase->getMemberDeclarationNames())
+                        {
+                            StructMember *memberDeclaration = unionCase->getUnionMemberDeclaration(caseMemberName);
+                            string unionCaseName = name + disriminatorSeparator + getOutputName(memberDeclaration);
+                            memberData["coderCall"] =
+                                getEncodeDecodeCall(unionCaseName, group, memberDeclaration->getDataType(), structType,
+                                                    true, structMember, casesNeedTempVariable, isFunctionParam);
+                            if (generateServerFreeFunctions(structMember) &&
+                                isNeedCallFree(memberDeclaration->getDataType()))
+                            {
+                                // set freeing function for current union
+                                templateData["freeingCall"] = m_templateData["freeUnion"];
+                                // current case need free memory
+                                caseData["needCaseFreeingCall"] = true;
+                                // current member need free memory
+                                memberData["isNeedFreeingCall"] = true;
+                            }
+                            else
+                            {
+                                // current member don't need free memory
+                                memberData["isNeedFreeingCall"] = false;
+                                needCaseEmptyFreeingCall = true;
+                            }
+                            caseMembers.push_back(memberData);
+                            if (casesNeedTempVariable)
+                            {
+                                needTempVariable = true;
+                            }
+                        }
+                    }
+                    caseData["members"] = caseMembers;
+                    unionCases.push_back(caseData);
+                }
+                templateData["cases"] = unionCases;
+                templateData["needCaseEmptyFreeingCall"] = needCaseEmptyFreeingCall;
+                templateData["encode"] = m_templateData["encodeUnionType"];
+                templateData["decode"] = m_templateData["decodeUnionType"];
+            }
+            break;
+        }
+        default: {
+            throw internal_error("unknown member type");
+        }
+    }
+    return templateData;
+}
+
+void CPPGenerator::giveBracesToArrays(string &name)
+{
+    if (name.size() && name.substr(0, 1) == "*")
+    {
+        name = "(" + name + ")";
+    }
+}
+
+string CPPGenerator::getExtraPointerInReturn(DataType *dataType)
+{
+    DataType *trueDataType = dataType->getTrueDataType();
+    if (trueDataType->isStruct() || trueDataType->isArray() || trueDataType->isUnion())
+    {
+        return "*";
+    }
+
+    return "";
+}
+
+string CPPGenerator::getExtraDirectionPointer(StructMember *structMember)
+{
+    DataType *dataType = structMember->getDataType();
+    DataType *trueDataType = dataType->getTrueDataType();
+    _param_direction structMemberDir = structMember->getDirection();
+    string result;
+    if (structMemberDir == kOutDirection) // between out and inout can be differences in future. Maybe not.
+    {
+        if (!trueDataType->isBuiltin() && !trueDataType->isEnum() && !trueDataType->isList() &&
+            !trueDataType->isArray())
+        {
+            result = "*";
+        }
+        if (findAnnotation(structMember, SHARED_ANNOTATION))
+        {
+            result += "*";
+        }
+    }
+    else if (structMemberDir == kInoutDirection)
+    {
+        if (!trueDataType->isBuiltin() && !trueDataType->isEnum() && !trueDataType->isList() &&
+            !trueDataType->isArray())
+        {
+            result = "*";
+        }
+        if (findAnnotation(structMember, SHARED_ANNOTATION))
+        {
+            result += "*";
+        }
+    }
+    else
+    {
+        if ((trueDataType->isStruct() || trueDataType->isUnion()) ||
+            (trueDataType->isScalar() && findAnnotation(structMember, SHARED_ANNOTATION)))
+        {
+            result = "*";
+        }
+    }
+
+    return result;
+}
+
+data_map CPPGenerator::firstAllocOnReturnWhenIsNeed(string name, DataType *dataType)
+{
+    DataType *trueDataType = dataType->getTrueDataType();
+    if ((trueDataType->isArray() || trueDataType->isStruct() || trueDataType->isUnion()) &&
+        !findAnnotation(dataType, SHARED_ANNOTATION))
+    {
+        return allocateCall(name, dataType);
+    }
+
+    data_map r;
+    return r;
+}
+
+data_map CPPGenerator::firstAllocOnServerWhenIsNeed(string name, StructMember *structMember)
+{
+    DataType *dataType = structMember->getDataType();
+    DataType *trueDataType = dataType->getTrueDataType();
+    _param_direction structMemberDir = structMember->getDirection();
+    if (!findAnnotation(structMember, SHARED_ANNOTATION))
+    {
+        if (structMemberDir == kInoutDirection)
+        {
+            if (!trueDataType->isBuiltin() && !trueDataType->isEnum() && !trueDataType->isList() &&
+                !trueDataType->isArray())
+            {
+                return allocateCall(name, structMember);
+            }
+        }
+        else if (structMemberDir == kInDirection)
+        {
+            if (trueDataType->isStruct() || trueDataType->isUnion())
+            {
+                return allocateCall(name, structMember);
+            }
+        }
+        else if (structMember->getDirection() == kOutDirection)
+        {
+            if (!trueDataType->isBuiltin() && !trueDataType->isEnum() && !trueDataType->isArray())
+            {
+                return allocateCall(name, structMember);
+            }
+            else if (trueDataType->isString())
+            {
+                if (!findAnnotation(structMember, MAX_LENGTH_ANNOTATION))
+                {
+                    Symbol *symbol = structMember;
+                    assert(symbol);
+                    throw semantic_error(
+                        format_string("For out string variable '%s' on line '%d' max_length annotation has to be set.",
+                                      symbol->getName().c_str(), symbol->getLocation().m_firstLine));
+                }
+                data_map returnValue = allocateCall(name, structMember);
+                returnValue["isOutChar"] = true;
+                return returnValue;
+            }
+        }
+    }
+
+    data_map r;
+    return r;
+}
+
+bool CPPGenerator::isNeedCallFree(DataType *dataType)
+{
+    DataType *trueDataType = dataType->getTrueDataType();
+    switch (trueDataType->getDataType())
+    {
+        case DataType::kArrayType: {
+            ArrayType *arrayType = dynamic_cast<ArrayType *>(trueDataType);
+            assert(arrayType);
+            return isNeedCallFree(arrayType->getElementType());
+        }
+        case DataType::kBuiltinType: {
+            BuiltinType *builtinType = dynamic_cast<BuiltinType *>(trueDataType);
+            assert(builtinType);
+            return builtinType->isString() || builtinType->isBinary();
+        }
+        case DataType::kListType: {
+            return true;
+        }
+        case DataType::kStructType: {
+            StructType *structType = dynamic_cast<StructType *>(trueDataType);
+            assert(structType);
+            set<DataType *> loopDetection;
+            return structType->containListMember() || structType->containStringMember() ||
+                   containsByrefParamToFree(structType, loopDetection);
+        }
+        case DataType::kUnionType: {
+            UnionType *unionType = dynamic_cast<UnionType *>(trueDataType);
+            assert(unionType);
+            for (auto unionCase : unionType->getCases())
+            {
+                if (!unionCase->caseMemberIsVoid())
+                {
+                    for (auto caseMemberName : unionCase->getMemberDeclarationNames())
+                    {
+                        StructMember *memberDeclaration = unionCase->getUnionMemberDeclaration(caseMemberName);
+                        if (isNeedCallFree(memberDeclaration->getDataType()))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+            return false;
+        }
+        default:
+            return false;
+    }
+}
+
+void CPPGenerator::setCallingFreeFunctions(Symbol *symbol, data_map &info, bool returnType)
+{
+    StructMember *structMember = dynamic_cast<StructMember *>(symbol);
+    assert(structMember);
+    DataType *trueDataType = structMember->getDataType()->getTrueDataType();
+    data_map firstFreeingCall1;
+    firstFreeingCall1["firstFreeingCall"] = "";
+    firstFreeingCall1["freeName"] = "";
+    // When true then function parameter, else return type
+    if (!findAnnotation(symbol, SHARED_ANNOTATION) && generateServerFreeFunctions(structMember))
+    {
+        if (!returnType)
+        {
+            if (trueDataType->isStruct() || trueDataType->isUnion() ||
+                (trueDataType->isFunction() && ((structMember->getDirection() == kOutDirection))))
+            {
+                string name = getOutputName(structMember, false);
+                firstFreeingCall1["firstFreeingCall"] = m_templateData["freeData"];
+                firstFreeingCall1["freeName"] = name;
+            }
+        }
+        else
+        {
+            if (trueDataType->isArray() || trueDataType->isStruct() || trueDataType->isUnion())
+            {
+                firstFreeingCall1["firstFreeingCall"] = m_templateData["freeData"];
+                firstFreeingCall1["freeName"] = "result";
+            }
+        }
+    }
+    info["firstFreeingCall1"] = firstFreeingCall1;
+}
+
+data_map CPPGenerator::allocateCall(const string &name, Symbol *symbol)
+{
+    StructMember *structMember = dynamic_cast<StructMember *>(symbol);
+    DataType *dataType;
+    data_map alloc;
+    if (structMember)
+    {
+        dataType = structMember->getDataType();
+    }
+    else
+    {
+        dataType = dynamic_cast<DataType *>(symbol);
+        assert(dataType);
+    }
+    DataType *trueDataType = dataType->getTrueDataType();
+    string size;
+    string chSize;
+    if ((trueDataType->isList() || trueDataType->isString()) && structMember)
+    {
+        size = getAnnStringValue(structMember, MAX_LENGTH_ANNOTATION);
+        if (size != "")
+        {
+            if (dataType->isString())
+            {
+                chSize = size;
+                size = "(" + size + " + 1)";
+            }
+            size += " * ";
+        }
+    }
+    if (dataType->isList())
+    {
+        ListType *listType = dynamic_cast<ListType *>(dataType);
+        assert(listType);
+        dataType = listType->getElementType();
+        if (size == "")
+        {
+            size = listType->getLengthVariableName() + " * ";
+        }
+    }
+    string typeValue;
+    string typePointerValue;
+    if (!dataType->isString())
+    {
+        typeValue = getTypenameName(dataType, "");
+        typePointerValue = getTypenameName(dataType, "*");
+    }
+    else
+    {
+        typeValue = "char";
+        typePointerValue = dataType->isUString() ? "unsigned char*" : "char *";
+    }
+
+    alloc["name"] = name.c_str();
+    alloc["typePointerValue"] = typePointerValue.c_str();
+    alloc["size"] = size.c_str();
+    alloc["chSize"] = chSize.c_str();
+    alloc["typeValue"] = typeValue.c_str();
+    alloc["isOutChar"] = false;
+    return alloc;
+}
+
+string CPPGenerator::returnSpaceWhenNotEmpty(const string &param)
+{
+    return (param == "") ? "" : " ";
+}
+
+bool CPPGenerator::containsString(DataType *dataType)
+{
+    if (dataType->getTrueDataType()->isList())
+    {
+        ListType *l = dynamic_cast<ListType *>(dataType->getTrueDataType());
+        assert(l);
+        return containsString(l->getElementType());
+    }
+    DataType *trueDataType = dataType->getTrueContainerDataType();
+    switch (trueDataType->getDataType())
+    {
+        case DataType::kStructType: {
+            StructType *s = dynamic_cast<StructType *>(trueDataType);
+            assert(s);
+            return s->containStringMember();
+        }
+        case DataType::kUnionType: {
+            UnionType *u = dynamic_cast<UnionType *>(trueDataType);
+            assert(u);
+            for (UnionCase *unionCase : u->getUniqueCases())
+            {
+                if (!unionCase->caseMemberIsVoid())
+                {
+                    for (string unionCaseName : unionCase->getMemberDeclarationNames())
+                    {
+                        StructMember *unionCaseMember = unionCase->getUnionMemberDeclaration(unionCaseName);
+                        if (containsString(unionCaseMember->getDataType()))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+            return false;
+        }
+        default: {
+            if (trueDataType->isString())
+            {
+                return true;
+            }
+            return false;
+        }
+    }
+}
+
+bool CPPGenerator::containsList(DataType *dataType)
+{
+    if (dataType->getTrueDataType()->isList())
+    {
+        return true;
+    }
+    DataType *trueDataType = dataType->getTrueContainerDataType();
+    switch (trueDataType->getDataType())
+    {
+        case DataType::kStructType: {
+            StructType *s = dynamic_cast<StructType *>(trueDataType);
+            assert(s);
+            return s->containListMember();
+        }
+        case DataType::kUnionType: {
+            UnionType *u = dynamic_cast<UnionType *>(trueDataType);
+            assert(u);
+            for (UnionCase *unionCase : u->getUniqueCases())
+            {
+                if (!unionCase->caseMemberIsVoid())
+                {
+                    for (string unionCaseName : unionCase->getMemberDeclarationNames())
+                    {
+                        StructMember *unionCaseMember = unionCase->getUnionMemberDeclaration(unionCaseName);
+                        if (containsList(unionCaseMember->getDataType()))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+            return false;
+        }
+        default: {
+            return false;
+        }
+    }
+}
+
+bool CPPGenerator::containsByrefParamToFree(DataType *dataType, set<DataType *> &dataTypes)
+{
+    // For loops from forward declaration detection.
+    if (dataTypes.insert(dataType).second)
+    {
+        DataType *trueDataType = dataType->getTrueContainerDataType();
+        if (trueDataType->isStruct())
+        {
+            StructType *structType = dynamic_cast<StructType *>(trueDataType);
+            assert(structType != nullptr);
+
+            for (StructMember *structMember : structType->getMembers())
+            {
+                if ((structMember->isByref() && !findAnnotation(structMember, SHARED_ANNOTATION)) ||
+                    containsByrefParamToFree(structMember->getDataType(), dataTypes))
+                {
+                    return true;
+                }
+            }
+        }
+        else if (trueDataType->isUnion())
+        {
+            UnionType *unionType = dynamic_cast<UnionType *>(trueDataType);
+            assert(unionType != nullptr);
+
+            for (StructMember *structMember : unionType->getUnionMembers().getMembers())
+            {
+                if ((structMember->isByref() && !findAnnotation(structMember, SHARED_ANNOTATION)) ||
+                    containsByrefParamToFree(structMember->getDataType(), dataTypes))
+                {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
+bool CPPGenerator::isListStruct(StructType *structType)
+{
+    // if structure is transformed list<> to struct{list<>}
+    for (StructType *structList : m_structListTypes)
+    {
+        if (structType == structList)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool CPPGenerator::isBinaryStruct(StructType *structType)
+{
+    // if structure contains one member list<>
+    if (structType->getMembers().size() == 1 && structType->getMembers()[0]->getDataType()->isList())
+    {
+        /*
+         * If list is same as in s_listBinaryTypes.
+         * This list is always in 0-position of vector s_listBinaryTypes.
+         */
+        if (m_listBinaryTypes.size() && structType->getMembers()[0]->getDataType() == m_listBinaryTypes.at(0))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool CPPGenerator::isBinaryList(ListType *listType)
+{
+
+    // If list is same as in s_listBinaryTypes.
+    for (ListType *list : m_listBinaryTypes)
+    {
+        if (listType == list)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool CPPGenerator::generateServerFreeFunctions(StructMember *structMember)
+{
+    return (structMember == nullptr || findAnnotation(structMember, RETAIN_ANNOTATION) == nullptr);
+}
+
+void CPPGenerator::setNoSharedAnn(Symbol *parentSymbol, Symbol *childSymbol)
+{
+    if (Annotation *ann = findAnnotation(childSymbol, NO_SHARED_ANNOTATION))
+    {
+        parentSymbol->addAnnotation(*ann);
+    }
+}
+
+bool CPPGenerator::setDiscriminatorTemp(UnionType *unionType, StructType *structType, StructMember *structMember,
+                                      bool isFunctionParam, data_map &templateData)
+{
+    bool needTempVariable = false;
+    if (structType)
+    {
+        string discriminatorName;
+        Symbol *disSymbol;
+
+        if (unionType->isNonEncapsulatedUnion())
+        {
+            discriminatorName = getAnnStringValue(structMember, DISCRIMINATOR_ANNOTATION);
+            disSymbol = m_globals->getSymbol(discriminatorName, false);
+            if (isFunctionParam || disSymbol)
+            {
+                templateData["dataLiteral"] = "";
+            }
+            else
+            {
+                templateData["dataLiteral"] = "data->";
+            }
+        }
+        else
+        {
+            disSymbol = nullptr;
+            templateData["dataLiteral"] = "data->";
+            discriminatorName = unionType->getDiscriminatorName();
+        }
+
+        DataType *disType;
+        if (disSymbol)
+        {
+            templateData["isConstant"] = true;
+            ConstType *constType = dynamic_cast<ConstType *>(disSymbol);
+            assert(constType);
+            disType = constType->getDataType();
+        }
+        else
+        {
+            templateData["isConstant"] = false;
+            disSymbol = structType->getScope().getSymbol(discriminatorName);
+            assert(disSymbol);
+            StructMember *disMember = dynamic_cast<StructMember *>(disSymbol);
+            assert(disMember);
+            disType = disMember->getDataType();
+        }
+
+        BuiltinType *disBuiltin = dynamic_cast<BuiltinType *>(disType->getTrueDataType());
+        if (disBuiltin && disBuiltin->getBuiltinType() == BuiltinType::kInt32Type)
+        {
+            templateData["castDiscriminator"] = false;
+        }
+        else
+        {
+            needTempVariable = true;
+            templateData["castDiscriminator"] = true;
+            templateData["discriminatorType"] = disType->getName();
+        }
+        templateData["discriminatorName"] = discriminatorName;
+    }
+    else
+    {
+        templateData["discriminatorName"] = "discriminator";
+        templateData["dataLiteral"] = "";
+        templateData["castDiscriminator"] = false;
+    }
+    return needTempVariable;
+}
+
+string CPPGenerator::getScalarTypename(DataType *dataType)
+{
+    if (dataType->getTrueDataType()->isScalar())
+    {
+        if (dataType->isAlias())
+        {
+            return dataType->getName();
+        }
+        else
+        {
+            BuiltinType *builtinType = dynamic_cast<BuiltinType *>(dataType);
+            assert(builtinType);
+            return getBuiltinTypename(builtinType);
+        }
+    }
+    else
+    {
+        return "";
+    }
+}
+
+string CPPGenerator::getDirection(_param_direction direction)
+{
+    switch (direction)
+    {
+        case kInDirection:
+            return "kInDirection";
+        case kOutDirection:
+            return "kOutDirection";
+        case kInoutDirection:
+            return "kInoutDirection";
+        case kReturn:
+            return "kReturn";
+        default:
+            throw semantic_error("Unsupported direction type");
+    }
+}
+
+void CPPGenerator::initCReservedWords()
+{
+    // C specific words
+    reserverdWords.insert("if");
+    reserverdWords.insert("else");
+    reserverdWords.insert("switch");
+    reserverdWords.insert("case");
+    reserverdWords.insert("default");
+    reserverdWords.insert("break");
+    reserverdWords.insert("int");
+    reserverdWords.insert("float");
+    reserverdWords.insert("char");
+    reserverdWords.insert("double");
+    reserverdWords.insert("long");
+    reserverdWords.insert("for");
+    reserverdWords.insert("while");
+    reserverdWords.insert("do");
+    reserverdWords.insert("void");
+    reserverdWords.insert("goto");
+    reserverdWords.insert("auto");
+    reserverdWords.insert("signed");
+    reserverdWords.insert("const");
+    reserverdWords.insert("extern");
+    reserverdWords.insert("register");
+    reserverdWords.insert("unsigned");
+    reserverdWords.insert("return");
+    reserverdWords.insert("continue");
+    reserverdWords.insert("enum");
+    reserverdWords.insert("sizeof");
+    reserverdWords.insert("struct");
+    reserverdWords.insert("typedef");
+    reserverdWords.insert("union");
+    reserverdWords.insert("volatile");
+    reserverdWords.insert("bool");
+    reserverdWords.insert("int8_t");
+    reserverdWords.insert("int16_t");
+    reserverdWords.insert("int32_t");
+    reserverdWords.insert("int64_t");
+    reserverdWords.insert("uint8_t");
+    reserverdWords.insert("uint16_t");
+    reserverdWords.insert("uint32_t");
+    reserverdWords.insert("uint64_t");
+
+    // C++ specific words
+    reserverdWords.insert("asm");
+    reserverdWords.insert("catch");
+    reserverdWords.insert("class");
+    reserverdWords.insert("const_cast");
+    reserverdWords.insert("delete");
+    reserverdWords.insert("dynamic_cast");
+    reserverdWords.insert("explicit");
+    reserverdWords.insert("false");
+    reserverdWords.insert("friend");
+    reserverdWords.insert("inline");
+    reserverdWords.insert("mutable");
+    reserverdWords.insert("namespace");
+    reserverdWords.insert("new");
+    reserverdWords.insert("operator");
+    reserverdWords.insert("private");
+    reserverdWords.insert("public");
+    reserverdWords.insert("protected");
+    reserverdWords.insert("reinterpret_cast");
+    reserverdWords.insert("static_cast");
+    reserverdWords.insert("template");
+    reserverdWords.insert("this");
+    reserverdWords.insert("throw");
+    reserverdWords.insert("true");
+    reserverdWords.insert("try");
+    reserverdWords.insert("typeid");
+    reserverdWords.insert("typename");
+    reserverdWords.insert("using");
+    reserverdWords.insert("virtual");
+    reserverdWords.insert("wchar_t");
+}
+
+void CPPGenerator::checkIfAnnValueIsIntNumberOrIntType(Annotation *ann, StructType *currentStructType)
+{
+    // skip if value is integer number
+    if (ann->getValueObject()->getType() != kIntegerValue)
+    {
+        string annName = ann->getName();
+        int annNameFirstLine = ann->getLocation().m_firstLine;
+        string annValue = ann->getValueObject()->toString();
+
+        DataType *trueDataType = nullptr;
+
+        // search in structure scope for member referenced with annotation
+        for (StructMember *structMember : currentStructType->getMembers())
+        {
+            if (structMember->getName().compare(annValue) == 0)
+            {
+                trueDataType = structMember->getDataType()->getTrueDataType();
+                break;
+            }
+        }
+
+        if (!trueDataType)
+        {
+            // search in global scope for member referenced with annotation
+            Symbol *symbolConst = m_globals->getSymbol(annValue);
+            if (symbolConst)
+            {
+                ConstType *constVar = dynamic_cast<ConstType *>(symbolConst);
+                if (constVar)
+                {
+                    trueDataType = constVar->getDataType();
+                }
+            }
+        }
+
+        if (trueDataType)
+        {
+            // check if data type is integer type
+            if (trueDataType->isScalar())
+            {
+                BuiltinType *builtinType = dynamic_cast<BuiltinType *>(trueDataType);
+                if (builtinType && builtinType->isInt())
+                {
+                    return;
+                }
+            }
+
+            throw semantic_error(format_string(
+                "line %d: Annotation %s contains reference to non-integer parameter or member %s declared on line %d.",
+                annNameFirstLine, annName.c_str(), annValue.c_str(), trueDataType->getLocation().m_firstLine));
+        }
+        else
+        {
+            throw semantic_error(format_string("line %d: The parameter or member named by a %s annotation must exist.",
+                                               annNameFirstLine, annName.c_str()));
+        }
+    }
+}
+
+void CPPGenerator::scanStructForAnnotations(StructType *currentStructType, bool isFunction)
+{
+    // go trough all structure members
+    for (StructMember *structMember : currentStructType->getMembers())
+    {
+        DataType *memberType = structMember->getDataType()->getTrueDataType();
+        /* Check non-encapsulated discriminated unions. */
+        // looking for references
+        Annotation *lengthAnn = findAnnotation(structMember, LENGTH_ANNOTATION);
+        Annotation *maxLengthAnn = findAnnotation(structMember, MAX_LENGTH_ANNOTATION);
+        if (lengthAnn)
+        {
+            checkIfAnnValueIsIntNumberOrIntType(lengthAnn, currentStructType);
+
+            if (lengthAnn->getValueObject()->getType() != kIntegerValue)
+            {
+                StructMember *structMemberRef = NULL;
+
+                // search in structure scope for member referenced with annotation
+                Symbol *symbol =
+                    currentStructType->getScope().getSymbol(lengthAnn->getValueObject()->toString(), false);
+                if (symbol)
+                {
+                    structMemberRef = dynamic_cast<StructMember *>(symbol);
+                    assert(structMemberRef);
+                }
+
+                // Verify both the data and length members are the same direction.
+                if (!isFunction && structMemberRef && structMember->getDirection() != structMemberRef->getDirection())
+                {
+                    throw semantic_error(
+                        format_string("orig line %d, ref line %d: The parameter named by a length annotation must be "
+                                      "the same direction as the data parameter.",
+                                      lengthAnn->getLocation().m_firstLine, structMember->getLocation().m_firstLine));
+                }
+                // Verify using max_length annotation when referenced variable is out.
+                else if (isFunction && structMemberRef && structMemberRef->getDirection() == kOutDirection &&
+                         !findAnnotation(structMember, MAX_LENGTH_ANNOTATION))
+                {
+                    throw semantic_error(
+                        format_string("orig line %d, ref line %d: The out parameter with set length annotation "
+                                      "must have also set max_length annotation",
+                                      lengthAnn->getLocation().m_firstLine, structMember->getLocation().m_firstLine));
+                }
+                // Verify using max_length annotation when referenced variable is inout.
+                else if (isFunction && structMemberRef && structMember->getDirection() == kInoutDirection &&
+                         structMemberRef->getDirection() == kInoutDirection &&
+                         !findAnnotation(structMember, MAX_LENGTH_ANNOTATION))
+                {
+                    throw semantic_error(
+                        format_string("orig line %d, ref line %d: The inout parameter named by a length annotation "
+                                      "must have set max_length annotation",
+                                      lengthAnn->getLocation().m_firstLine, structMember->getLocation().m_firstLine));
+                }
+            }
+
+            // Set length variable name.
+            if (memberType->isList())
+            {
+                ListType *memberListType = dynamic_cast<ListType *>(memberType);
+                assert(memberListType);
+                memberListType->setLengthVariableName(lengthAnn->getValueObject()->toString());
+            }
+        }
+
+        if (maxLengthAnn)
+        {
+            checkIfAnnValueIsIntNumberOrIntType(maxLengthAnn, currentStructType);
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// EOF
+////////////////////////////////////////////////////////////////////////////////

--- a/erpcgen/src/CPPGenerator.cpp
+++ b/erpcgen/src/CPPGenerator.cpp
@@ -1682,7 +1682,9 @@ data_map CPPGenerator::getFunctionTemplateData(Group *group, Function *fn)
     }
 
     string proto = getFunctionPrototype(group, fn);
+    string proto_no_scope = getFunctionPrototype(group, fn, "", false);
     info["prototype"] = proto;
+    info["prototype_no_scope"] = proto_no_scope;
     info["name"] = getOutputName(fn);
     info["id"] = fn->getUniqueId();
 
@@ -1935,7 +1937,7 @@ string CPPGenerator::getFunctionServerCall(Function *fn, FunctionType *functionT
     return proto + ");";
 }
 
-string CPPGenerator::getFunctionPrototype(Group *group, FunctionBase *fn, std::string name)
+string CPPGenerator::getFunctionPrototype(Group *group, FunctionBase *fn, std::string name, bool scoped)
 {
     DataType *dataTypeReturn = fn->getReturnType();
     string proto = getExtraPointerInReturn(dataTypeReturn);
@@ -1960,9 +1962,9 @@ string CPPGenerator::getFunctionPrototype(Group *group, FunctionBase *fn, std::s
         }
         else /* Use function name only. */
         {
-            if (group != nullptr)
+            if (group != nullptr && scoped)
             {
-                proto += iface_group_name + "_client_t";
+                proto += iface_group_name + "_client";
                 proto += "::";
             }
             proto += functionName;

--- a/erpcgen/src/CPPGenerator.h
+++ b/erpcgen/src/CPPGenerator.h
@@ -1,0 +1,790 @@
+/*
+ * Copyright (c) 2014-2016, Freescale Semiconductor, Inc.
+ * Copyright 2016-2017 NXP
+ * All rights reserved.
+ *
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _EMBEDDED_RPC__CPPGENERATOR_H_
+#define _EMBEDDED_RPC__CPPGENERATOR_H_
+
+#include "Generator.h"
+#include "cpptempl.h"
+#include "types/Group.h"
+
+#include <set>
+
+////////////////////////////////////////////////////////////////////////////////
+// Classes
+////////////////////////////////////////////////////////////////////////////////
+
+namespace erpcgen {
+/*!
+ * @brief Code generator for C.
+ */
+class CPPGenerator : public Generator
+{
+public:
+    /*!
+     * @brief This function is constructor of CPPGenerator class.
+     *
+     * Interface definition contains all information about parsed files and builtin types.
+     *
+     * @param[in] def Contains all Symbols parsed from IDL files.
+     */
+    CPPGenerator(InterfaceDefinition *def);
+
+    /*!
+     * @brief This function is destructor of CPPGenerator class.
+     *
+     * This function close opened files.
+     */
+    virtual ~CPPGenerator() {}
+
+    /*!
+     * @brief This function generate output code for output files.
+     *
+     * This code call all necessary functions for prepare output code and parse it into output files.
+     */
+    virtual void generate();
+
+private:
+    enum _direction
+    {
+        kIn,
+        kOut,
+        kInOut,
+        kNone
+    };
+
+    cpptempl::data_list m_symbolsTemplate; /*!< List of all symbol templates */
+
+    std::vector<ListType *>
+        m_listBinaryTypes; /*!<
+                            * Contains binary types transformed to list<uint8>.
+                            * More ListType are present when @length annotation is used for binary type.
+                            * If binary without @length is used then it is placed on first place in this vector.
+                            */
+
+    std::vector<StructType *> m_structListTypes; /*!<
+                                                  * Contains list types transformed to struct{list<>}.
+                                                  * To distinguish between user defined struct{list<>} and transformed
+                                                  * list<> to struct{list<>}.
+                                                  */
+
+    /*!
+     * @brief This function prepare helpful functions located in template files.
+     *
+     * These function may be used while parsing templates
+     */
+    void parseSubtemplates();
+
+    /*!
+     * @brief This function generate output files.
+     *
+     * This function call functions for generating client/server header/source files.
+     *
+     * @param[in] fileNameExtension Extension for file name (for example for case that each interface will be generated
+     * in its set of output files).
+     */
+    void generateOutputFiles(const std::string &fileNameExtension);
+
+    /*!
+     * @brief This function generate output common types header file.
+     *
+     * @param[in] fileName Name for output client source file.
+     */
+    void generateTypesHeaderFile();
+
+    /*!
+     * @brief This function generate output common header file.
+     *
+     * @param[in] fileName Name for output client source file.
+     */
+    void generateCommonHeaderFiles(const std::string &fileName);
+
+    /*!
+     * @brief This function generate output client source file.
+     *
+     * @param[in] fileName Name for output client source file.
+     */
+    void generateClientSourceFile(std::string fileName);
+
+    /*!
+     * @brief This function generate output server header file.
+     *
+     * @param[in] fileName Name for output server header file.
+     */
+    void generateServerHeaderFile(std::string fileName);
+
+    /*!
+     * @brief This function generate output server source file.
+     *
+     * @param[in] fileName Name for output server source file.
+     */
+    void generateServerSourceFile(std::string fileName);
+
+    /*!
+     * @brief This function generate output crc16 source file.
+     */
+    virtual void generateCrcFile();
+
+    /*!
+     * @brief This function transforms alias data type to list or structure.
+     */
+    void transformAliases();
+
+    /*!
+     * @brief This function gets template for symbol specified by name.
+     *
+     * @param[in] name Symbol name.
+     *
+     * @return Template for symbol defined by name.
+     */
+    cpptempl::data_map getSymbolTemplateByName(const std::string &name);
+
+    /*!
+     * @brief This function change list and binary data type to structure.
+     *
+     * This function return given data type or new structure data type.
+     * If given data type contains list or binary data type, then this data type will be changed to the structure.
+     * New created structure is placed before top data type.
+     *
+     * @param[inout] dataTypes Vector of transformed data types.
+     * @param[in] dataType Top data type.
+     *
+     * @return Pointer to given or new DataType.
+     */
+    DataType *findChildDataType(std::set<DataType *> &dataTypes, DataType *dataType);
+
+    /*!
+     * @brief This function transform binary data type to list and set annotation to it.
+     *
+     * @param[in] structMember Structure member, Function parameter or Union member.
+     */
+    void setBinaryList(StructMember *structMember);
+
+    /*!
+     * @brief This function returns function base template data.
+     *
+     * This function returns function base template data with all data, which
+     * are necessary for generating output code for output files.
+     *
+     * @param[in] group Group to which function belongs.
+     * @param[in] fn From this are set function base template data.
+     *
+     * @return Contains function base data.
+     */
+    cpptempl::data_map getFunctionBaseTemplateData(Group *group, FunctionBase *fn);
+
+    /*!
+     * @brief This function returns interface function template data.
+     *
+     * This function returns interface function template data with all data, which
+     * are necessary for generating output code for output files.
+     *
+     * @param[in] group Group to which function belongs.
+     * @param[in] fn From this are set interface function template data.
+     *
+     * @return Contains interface function data.
+     */
+    cpptempl::data_map getFunctionTemplateData(Group *group, Function *fn);
+
+    /*!
+     * @brief This function returns function type (callbacks type) template data.
+     *
+     * This function returns function type (callbacks type) template data with all data, which
+     * are necessary for generating output code for output files. Shim code is generating
+     * common function for serialization/deserialization of data.
+     *
+     * @param[in] group Group to which function belongs.
+     * @param[in] fn From this are set function type template data.
+     *
+     * @return Contains interface function data.
+     */
+    cpptempl::data_map getFunctionTypeTemplateData(Group *group, FunctionType *fn);
+
+    /*!
+     * @brief This function will get symbol comments and convert to language specific ones
+     *
+     * @param[in] symbol Pointer to symbol.
+     * @param[inout] symbolInfo Data map, which contains information about symbol.
+     */
+    void setTemplateComments(Symbol *symbol, cpptempl::data_map &symbolInfo);
+
+    /*!
+     * @brief This function sets const template data.
+     *
+     * This function sets const template data with all data, which
+     * are necessary for generating output code for output files.
+     */
+    void makeConstTemplateData();
+
+    // Functions that populate type-specific template data
+
+    /*!
+     * @brief This function sets group symbols template data.
+     *
+     * This function sets group symbols template data with all data, which
+     * are necessary for generating output code for output files.
+     *
+     * @param[in] group Pointer to a group.
+     *
+     * @return Data map with group symbols templates.
+     */
+    cpptempl::data_map makeGroupSymbolsTemplateData(Group *group);
+
+    /*!
+     * @brief This function sets group callbacks template data.
+     *
+     * This function sets group callbacks template data with all data, which
+     * are necessary for generating output code for output files.
+     *
+     * @param[in] group Pointer to a group.
+     *
+     * @return Data list of group function types (callback types).
+     */
+    cpptempl::data_list makeGroupCallbacksTemplateData(Group *group);
+
+    /*!
+     * @brief This function returns template data for given structure.
+     *
+     * This function return structure's template data with necessary data
+     * for generating output code for structure declaration.
+     *
+     * @param[in] structType Given structure type.
+     *
+     * @return Data map with structure template data.
+     */
+    cpptempl::data_map getStructDeclarationTemplateData(StructType *structType);
+
+    /*!
+     * @brief This function return template data for given structure.
+     *
+     * This function return structure's template data with all data, which
+     * are necessary for generating output code for output files.
+     *
+     * It needs to have struct declaration as an input.
+     *
+     * @param[in] group Pointer to a group.
+     * @param[in] structType Given structure type.
+     * @param[in] structInfo Struct declaration template.
+     *
+     * @return Data map with structure template data.
+     */
+    cpptempl::data_map getStructDefinitionTemplateData(Group *group, StructType *structType,
+                                                       cpptempl::data_map structInfo);
+
+    /*!
+     * @brief This function returns template data for given union.
+     *
+     * This function return union template data with necessary data
+     * for generating output code for union declaration.
+     *
+     * @param[in] unionType Given union type.
+     *
+     * @return Data map with union template data.
+     */
+    cpptempl::data_map getUnionDeclarationTemplateData(UnionType *unionType);
+
+    /*!
+     * @brief This function return template data for given union.
+     *
+     * This function return union template data with all data, which
+     * are necessary for generating output code for output files.
+     *
+     * It needs to have union declaration as an input.
+     *
+     * @param[in] group Pointer to a group.
+     * @param[in] unionType Given union type.
+     * @param[in] unionInfo Union declaration template.
+     * @param[inout] needUnionsServerFree Bool indication if server code needs to have deallocation of the union.
+     *
+     * @return Data map with union template data.
+     */
+    cpptempl::data_map getUnionDefinitionTemplateData(Group *group, UnionType *unionType, cpptempl::data_map &unionInfo,
+                                                      bool &needUnionsServerFree);
+    /*!
+     * @brief This function sets union cases template data.
+     *
+     * This function sets unions cases template data for given union, which
+     * is necessary for generating output code for output files.
+     *
+     * @param[in] unionType Union, which contains union cases.
+     * @param[in] unionInfo Data map for which data should be set.
+     */
+    void setUnionMembersTemplateData(UnionType *unionType, cpptempl::data_map &unionInfo);
+
+    /*!
+     * @brief This function returns union cases declaration description to union.
+     *
+     * This function returns unions cases declaration description to union, which
+     * is necessary for generating union encapsulated data type.
+     *
+     * @param[in] unionType Union, which contains union cases.
+     * @param[in] indent Additional indent used for member data.
+     *
+     * @return Union cases declaration description.
+     */
+    std::string getUnionMembersData(UnionType *unionType, std::string indent);
+
+    /*!
+     * @brief This function sets enum template data.
+     *
+     * This function sets enum template data with all data, which
+     * are necessary for generating output code for output files.
+     */
+    void makeEnumsTemplateData();
+
+    /*!
+     * @brief This function sets enum template data.
+     *
+     * This function sets enum template data with all data, which
+     * are necessary for generating output code for output files.
+     */
+    void makeSymbolsDeclarationTemplateData();
+
+    /*!
+     * @brief This function return template data for given enum.
+     *
+     * This function return enum's template data with all data, which
+     * are necessary for generating output code for output files.
+     *
+     * @param[in] enumType Given enum type.
+     *
+     * @return Contain enum template data.
+     */
+    cpptempl::data_map getEnumTemplateData(EnumType *enumType);
+
+    /*!
+     * @brief This function return enum members template data.
+     *
+     * This function return enum members template data with all data, which
+     * are necessary for generating output code for output files.
+     *
+     * @param[in] enumType Pointer to enum.
+     *
+     * @return Contains enum members data.
+     */
+    cpptempl::data_list getEnumMembersTemplateData(EnumType *enumType);
+
+    /*!
+     * @brief This function sets alias (type definition) template data.
+     *
+     * This function sets alias template data with all data, which
+     * are necessary for generating output code for output files.
+     */
+    void makeAliasesTemplateData();
+
+    /*!
+     * @brief This function returns alias type of given DataType.
+     *
+     * @return AliasType or nullptr, when alias was not find.
+     */
+    AliasType *getAliasType(DataType *dataType);
+
+    /*!
+     * @brief This function returns alias name of given DataType.
+     *
+     * @return Alias name or empty string, when alias was not find.
+     */
+    std::string getAliasName(DataType *dataType);
+
+    /*!
+     * @brief This function return necessary template data for data type.
+     *
+     * This function return data type template data with all necessary data, which
+     * are necessary for generating output code for output files.
+     *
+     * @param[in] t From this are set data type template data.
+     * @param[in] isFunction If set to true return parameters will have
+     *          comma at start of sequence.
+     *
+     * @return Contains data type template data.
+     */
+    cpptempl::data_map getTypeInfo(DataType *t, bool isFunction);
+
+    /*!
+     * @brief This function returns error return value for given function.
+     *
+     * @param[in] fn Function from which is returned error return value.
+     *
+     * @return Return string representation of error return value.
+     */
+    std::string getErrorReturnValue(FunctionBase *fn);
+
+    /*!
+     * @brief This function return interface function prototype.
+     *
+     * @param[in] group Group to which function belongs.
+     * @param[in] fn Function for prototyping.
+     * @param[in] name Name used for FunctionType.
+     *
+     * @return String prototype representation for given function.
+     */
+    std::string getFunctionPrototype(Group *group, FunctionBase *fn, std::string name = "");
+
+    /*!
+     * @brief This function return interface function representation called by server side.
+     *
+     * @param[in] fn Function for interface function representation.
+     * @param[in] functionType Inside FunctionType common shim code server call need use FunctionType parameters names.
+     *
+     * @return String representation for given function.
+     */
+    std::string getFunctionServerCall(Function *fn, FunctionType *functionType = nullptr);
+
+    /*!
+     * @brief This function return name with guard.
+     *
+     * @param[in] filename File name for guard name.
+     *
+     * @return Guard name.
+     */
+    std::string generateIncludeGuardName(const std::string &filename);
+
+    /*!
+     * @brief This function return string representation for given BuiltinType.
+     *
+     * @param[in] t Builtin type.
+     *
+     * return std::string String representation for given builtin type.
+     */
+    std::string getBuiltinTypename(const BuiltinType *t);
+
+    /*!
+     * @brief This function set to variable returnName type or type with variable name.
+     *
+     * This function set to variable returnName "type" if given returnName is "",
+     * or return "type with variable name", when given returnName is set to
+     * variable name.
+     *
+     * @param[in] t data type.
+     * @param[in] name Return type name.
+     *
+     * @return Return data type name with given name.
+     *
+     * @exception internal_error Thrown, when unknown data type is called.
+     */
+    std::string getTypenameName(DataType *t, const std::string &name);
+
+    /*!
+     * @brief This function return necessary template data for decode and encode data type.
+     *
+     * This function prepare data for decode or encode functions in c_coders template file.
+     *
+     * @param[in] name Variable name.
+     * @param[in] t Variable data type.
+     * @param[in] structType Structure holdings structure members.
+     * @param[in] inDataContainer Is inside data container (struct, list, array).
+     * @param[in] structMember Null for return.
+     * @param[out] needTempVariable Return true, when data type contains enum, function, union type.
+     * @param[in] isFunctionParam True for function param else false (structure member).
+     *
+     * @return Template data for decode or encode data type.
+     */
+    cpptempl::data_map getEncodeDecodeCall(const std::string &name, Group *group, DataType *t, StructType *structType,
+                                           bool inDataContainer, StructMember *structMember, bool &needTempVariable,
+                                           bool isFunctionParam);
+
+    /*!
+     * @brief This function add to template data, which kind of BuiltinType is data type.
+     *
+     * @param[in] t Data type.
+     * @param[out] templateData Template data.
+     * @param[in] structType Structure holdings structure members.
+     * @param[in] structMember Null for return.
+     * @param[in] isFunctionParam True for function param else false (structure member).
+     */
+    void getEncodeDecodeBuiltin(Group *group, BuiltinType *t, cpptempl::data_map &templateData, StructType *structType,
+                                StructMember *structMember, bool isFunctionParam);
+
+    /*!
+     * @brief This function encapsulate gave name, if it start with pointer.
+     *
+     * It is necessary for out and inout parameters, because int *a[] is not same as int (*a)[].
+     *
+     * @param[inout] name Variable name.
+     */
+    void giveBracesToArrays(std::string &name);
+
+    /*!
+     * @brief This function return "*", if it is need.
+     *
+     * It is need by rules of passing data types for each direction type.
+     *
+     * @param[in] structMember Contains direction type and data type.
+     *
+     * @return Pointer or empty.
+     */
+    std::string getExtraDirectionPointer(StructMember *structMember);
+
+    /*!
+     * @brief This function return "*", if it is need.
+     *
+     * It is need by rules of taking data types from return type.
+     *
+     * @param[in] dataType Data type.
+     *
+     * @return Pointer or empty.
+     */
+    std::string getExtraPointerInReturn(DataType *dataType);
+
+    /*!
+     * @brief This function call first erpc_alloc on server side for parameters if it is need (except out param).
+     *
+     * It is need by rules of passing data types for each direction type.
+     *
+     * @param[in] name Parameter name.
+     * @param[in] structMember Contains direction type and data type.
+     *
+     * @return Erpc_alloc function or empty.
+     */
+    cpptempl::data_map firstAllocOnServerWhenIsNeed(std::string name, StructMember *structMember);
+
+    /*!
+     * @brief This function call first erpc_alloc on client side return statement if it is need.
+     *
+     * It is need by rules of taking data types from return type.
+     *
+     * @param[in] name Parameter name.
+     * @param[in] dataType Contains data type information.
+     *
+     * @return Erpc_alloc function or empty.
+     */
+    cpptempl::data_map firstAllocOnReturnWhenIsNeed(std::string name, DataType *dataType);
+
+    /*!
+     * @brief This function return call for alloc space based on given data type.
+     *
+     * @param[in] name Name, for which is allocating space.
+     * @param[in] symbol Given symbol type contains annotations and data type.
+     *
+     * @return Return erpc_alloc call or empty string.
+     */
+    cpptempl::data_map allocateCall(const std::string &name, Symbol *symbol);
+
+    /*!
+     * @brief This function will add to given lists given map based on given by symbol direction.
+     *
+     * Based on directions of structures or functions parameters, given map will be added to given lists.
+     *
+     * @param[in] symbolType Contains structure or function parameter.
+     * @param[in] directions Set of directions
+     * @param[in,out] toClient List of data types designed for client direction.
+     * @param[in,out] toServer List of data types designed for server direction.
+     * @param[in] dataMap Map with information about structure or function parameter.
+     */
+    void setSymbolDataToSide(const Symbol *symbolType, const std::set<_param_direction> directions,
+                             cpptempl::data_list &toClient, cpptempl::data_list &toServer, cpptempl::data_map &dataMap);
+
+    /*!
+     * @brief This function returns true, when given data type need be freed.
+     *
+     * @param[in] dataType Given data type.
+     *
+     * @retval true When given data type need be freed.
+     * @retval false When given data type don't need be freed (like int, enum).
+     */
+    bool isNeedCallFree(DataType *dataType);
+
+    /*!
+     * @ This function set variables for calling first freeing function on server side for parameters, when it is need.
+     *
+     * It free what was allocated by this function: std::string firstAllocOnServerWhenIsNeed(std::string name,
+     * StructMember *structMember);
+     *
+     * @param[in] symbol StructMember when function parameter or DataType when return type.
+     * @param[in] info DataMap which contains information about data type for output.
+     * @param[in] returnType To recognize param type and return type.
+     */
+    void setCallingFreeFunctions(Symbol *symbol, cpptempl::data_map &info, bool returnType);
+
+    /*!
+     * @brief This function return space if given string is not empty.
+     *
+     * @param[in] param Given string.
+     *
+     * @return Space or empty.
+     */
+    std::string returnSpaceWhenNotEmpty(const std::string &param);
+
+    /*!
+     * @brief This function check, if data type contains string data type.
+     *
+     * @param[in] dataType Given data type.
+     *
+     * @retval True if data type contains string, else false.
+     *
+     * @see bool CPPGenerator::containsList(DataType * dataType)
+     * @see bool CPPGenerator::containsBinary(DataType * dataType)
+     */
+    bool containsString(DataType *dataType);
+
+    /*!
+     * @brief This function check, if data type contains list data type.
+     *
+     * @param[in] dataType Given data type.
+     *
+     * @retval True if data type contains list, else false.
+     *
+     * @see bool CPPGenerator::containsBinary(DataType * dataType)
+     * @see bool CPPGenerator::containsString(DataType * dataType)
+     */
+    bool containsList(DataType *dataType);
+
+    /*!
+     * @brief This function check, if data type is struct which contains byref parameter and not contains shared
+     * annotation.
+     *
+     * @param[in] dataType Given data type.
+     * @param[in] dataTypes For loops from forward declaration detection.
+     *
+     * @retval True if data type is structure and contains byref parameter and not contains shared annotation, else
+     * false.
+     *
+     */
+    bool containsByrefParamToFree(DataType *dataType, std::set<DataType *> &dataTypes);
+
+    /*!
+     * @brief This function returns true when structure is used as a wrapper for binary type.
+     *
+     * Binary type which is not using length annotation is in CPPGenerator presented as struct{ list<uint8> }.
+     *
+     * @param[in] structType Potential structure wrapper.
+     *
+     * @retval true When structure is used as a wrapper for binary type.
+     * @retval false When structure is not used as a wrapper for binary type.
+     */
+    bool isBinaryStruct(StructType *structType);
+
+    /*!
+     * @brief This function returns true when list was created for replacing binary type.
+     *
+     * Binary type which is using length annotation is in CPPGenerator presented as list<uint8>.
+     *
+     * @param[in] structType Potential structure wrapper.
+     *
+     * @retval true When structure is used as a wrapper for binary type.
+     * @retval false When structure is not used as a wrapper for binary type.
+     */
+    bool isBinaryList(ListType *listType);
+
+    /*!
+     * @brief This function returns true when structure is used as a wrapper for list type.
+     *
+     * @param[in] structType Potential structure wrapper.
+     *
+     * @retval true When structure is used as a wrapper for list type.
+     * @retval false When structure is not used as a wrapper for list type.
+     */
+    bool isListStruct(StructType *structType);
+
+    /*!
+     * @brief This function returns true when "retain" annotation wasn't set.
+     *
+     * This annotation have effect for server side of generated files. Allocated space will be not freed by server shim
+     * code.
+     *
+     * @param[in] structMember Function parameter.
+     *
+     * @retval true When "retain" annotation wasn't set.
+     * @retval false When "retain" annotation was set.
+     */
+    bool generateServerFreeFunctions(StructMember *structMember);
+
+    /*!
+     * @brief Set no_shared annotation to struct/union type.
+     *
+     * This annotation will be set to these data types if one of theirs members will contain mentioned annotation.
+     *
+     * @param[in] parentSymbol Struct/union type.
+     * @param[in] childSymbol It's member type.
+     */
+    void setNoSharedAnn(Symbol *parentSymbol, Symbol *childSymbol);
+
+    bool setDiscriminatorTemp(UnionType *unionType, StructType *structType, StructMember *structMember,
+                              bool isFunctionParam, cpptempl::data_map &templateData);
+
+    /*!
+     * @brief This function returns data type name for scalar data type.
+     *
+     * @param[in] dataType Data type to inspect.
+     *
+     * @retval Empty string when data type is not scalar.
+     * @retval Alias data name when dataType is AliasType.
+     * @retval Otherwise output from getBuiltinTypename.
+     */
+    std::string getScalarTypename(DataType *dataType);
+
+    /*!
+     * @brief This function returns string representations of function parameter direction.
+     *
+     * @param[in] direction Enum direction.
+     *
+     * @return String representation for given direction.
+     */
+    std::string getDirection(_param_direction direction);
+
+    /*!
+     * @brief This function returns information if function parameter on server side need be initialized to NULL.
+     *
+     * @param[in] structMember Function parameter.
+     *
+     * @retval true When Function parameter need to be initialized to NULL.
+     * @retval false When Function parameter don't need to be initialized to NULL.
+     */
+    bool isServerNullParam(StructMember *structMember);
+
+    /*!
+     * @brief This function returns information if function parameter is passed by pointer.
+     *
+     * @param[in] structMember Function parameter.
+     *
+     * @retval true When Function parameter is passed by pointer.
+     * @retval false When Function parameter isn't passed by pointer.
+     */
+    bool isPointerParam(StructMember *structMember);
+
+    /*!
+     * @brief This function returns information if function parameter is null-able.
+     *
+     * @param[in] structMember Function parameter.
+     *
+     * @retval true When Function parameter is null-able.
+     * @retval false When Function parameter isn't null-able.
+     */
+    bool isNullableParam(StructMember *structMember);
+
+    /*!
+     * Stores reserved words for C/C++ program language.
+     */
+    void initCReservedWords();
+
+    /*!
+     * @brief Controlling annotations used on structure members.
+     *
+     * Struct members are examined for @length and @max_length annotations, and the length member is denoted.
+     * This function is also used on function parameters, since they are covered by structs.
+     *
+     * @param[in] currentStructType StrucType to check.
+     * @param[in] isFunction To distinguish if given structure is used for function parameters.
+     */
+    void scanStructForAnnotations(StructType *currentStructType, bool isFunction);
+
+    /*!
+     * @brief Check if annotation is integer number or integer type variable.
+     *
+     * Annotation can contain reference to integer data type or it can be integer number.
+     * Referenced integer data type can be presented in global scope or in same structure scope.
+     *
+     * @param[in] ann Annotation to check.
+     * @param[in] currentStructType StrucType to check.
+     */
+    void checkIfAnnValueIsIntNumberOrIntType(Annotation *ann, StructType *currentStructType);
+};
+} // namespace erpcgen
+
+#endif // _EMBEDDED_RPC__CPPGENERATOR_H_

--- a/erpcgen/src/CPPGenerator.h
+++ b/erpcgen/src/CPPGenerator.h
@@ -421,6 +421,7 @@ private:
      * @param[in] group Group to which function belongs.
      * @param[in] fn Function for prototyping.
      * @param[in] name Name used for FunctionType.
+     * @param[in] scoped Whether to include class scope in the prototype.
      *
      * @return String prototype representation for given function.
      */

--- a/erpcgen/src/CPPGenerator.h
+++ b/erpcgen/src/CPPGenerator.h
@@ -424,7 +424,7 @@ private:
      *
      * @return String prototype representation for given function.
      */
-    std::string getFunctionPrototype(Group *group, FunctionBase *fn, std::string name = "");
+    std::string getFunctionPrototype(Group *group, FunctionBase *fn, std::string name = "", bool scoped=true);
 
     /*!
      * @brief This function return interface function representation called by server side.

--- a/erpcgen/src/Generator.cpp
+++ b/erpcgen/src/Generator.cpp
@@ -569,6 +569,10 @@ Annotation::program_lang_t Generator::getAnnotationLang()
     {
         return Annotation::kPython;
     }
+    else if (m_generatorType == kCPP)
+    {
+        return Annotation::kCPP;
+    }
 
     throw internal_error("Unsupported generator type specified for annotation.");
 }

--- a/erpcgen/src/Generator.h
+++ b/erpcgen/src/Generator.h
@@ -47,7 +47,8 @@ public:
     enum generator_type_t
     {
         kC,
-        kPython
+        kPython,
+        kCPP,
     }; /*!< Type of generator. */
 
     /*!

--- a/erpcgen/src/SymbolScanner.cpp
+++ b/erpcgen/src/SymbolScanner.cpp
@@ -1550,6 +1550,10 @@ Annotation::program_lang_t SymbolScanner::getAnnotationLang(AstNode *annotation)
         {
             return Annotation::kPython;
         }
+        else if (lang.compare("cpp") == 0)
+        {
+            return Annotation::kCPP;
+        }
 
         throw semantic_error(format_string("line %d: Unsupported programming language '%s' specified.",
                                            annotation->getToken().getFirstLine(), lang.c_str())

--- a/erpcgen/src/erpcgen.cpp
+++ b/erpcgen/src/erpcgen.cpp
@@ -10,6 +10,7 @@
 #include "erpc_version.h"
 
 #include "CGenerator.h"
+#include "CPPGenerator.h"
 #include "ErpcLexer.h"
 #include "InterfaceDefinition.h"
 #include "Logging.h"
@@ -98,6 +99,7 @@ protected:
     {
         kCLanguage,
         kPythonLanguage,
+        kCPPLanguage,
     }; /*!< Generated outputs format. */
 
     typedef vector<string> string_vector_t; /*!< Vector of positional arguments. */
@@ -202,6 +204,10 @@ public:
                     else if (lang == "py")
                     {
                         m_outputLanguage = kPythonLanguage;
+                    }
+                    else if (lang == "cpp")
+                    {
+                        m_outputLanguage = kCPPLanguage;
                     }
                     else
                     {
@@ -317,6 +323,9 @@ public:
                     break;
                 case kPythonLanguage:
                     PythonGenerator(&def).generate();
+                    break;
+                case kCPPLanguage:
+                    CPPGenerator(&def).generate();
                     break;
             }
         }

--- a/erpcgen/src/templates/cpp_client_source.template
+++ b/erpcgen/src/templates/cpp_client_source.template
@@ -28,7 +28,7 @@ using namespace erpc;
 using namespace std;
 
 {$generateCrcVariable()}
-
+using namespace erpc;
 namespace saas {
 
 {$> setSharedMemAddresses()}
@@ -186,8 +186,8 @@ static {$callbackType.prototype}
 {% endfor %}
 {% for iface in group.interfaces %}
 // {$iface.name}_client constructor.
-{$iface.name}_client::{$iface.name}_client() {
-    ManuallyConstructed<ClientManager> s_client
+{$iface.name}_client::{$iface.name}_client(erpc_transport_t transport, erpc_mbf_t message_buffer_factory) {
+    ManuallyConstructed<ClientManager> s_client;
     ManuallyConstructed<BasicCodecFactory> s_codecFactory;
     ManuallyConstructed<Crc16> s_crc16;
     erpc_assert(transport);

--- a/erpcgen/src/templates/cpp_client_source.template
+++ b/erpcgen/src/templates/cpp_client_source.template
@@ -14,8 +14,6 @@
 #include "erpc_port.h"
 #endif
 #include "{$codecHeader}"
-extern "C"
-{
 #include "{$commonHeaderName}.h"
 {% if groupNames %}
 // import callbacks declaration from other groups
@@ -23,7 +21,6 @@ extern "C"
 #include "{$outputFilename}_{$name}.h"
 {%  endfor %}
 {% endif %}
-}
 
 {$checkVersion()}
 {$>checkCrc()}

--- a/erpcgen/src/templates/cpp_client_source.template
+++ b/erpcgen/src/templates/cpp_client_source.template
@@ -3,8 +3,13 @@
 
 {% endif %}
 {$commonHeader()}
-
+#include "erpc_manually_constructed.h"
 #include "erpc_client_manager.h"
+#include "erpc_mbf_setup.h"
+#include "erpc_transport_setup.h"
+#include "erpc_crc16.h"
+#include "erpc_basic_codec.h"
+
 #if ERPC_ALLOCATION_POLICY == ERPC_ALLOCATION_POLICY_DYNAMIC
 #include "erpc_port.h"
 #endif
@@ -25,8 +30,10 @@ extern "C"
 using namespace erpc;
 using namespace std;
 
-extern ClientManager *g_client;
 {$generateCrcVariable()}
+
+namespace saas {
+
 {$> setSharedMemAddresses()}
 {% if unitTest %}
 {$> callbackTable(functions)}
@@ -51,7 +58,7 @@ extern ClientManager *g_client;
 {% endif -- isNotVoid %}
 
 #if ERPC_PRE_POST_ACTION
-    pre_post_action_cb preCB = g_client->getPreCB();
+    pre_post_action_cb preCB = mClient->getPreCB();
     if (preCB)
     {
         preCB();
@@ -60,9 +67,9 @@ extern ClientManager *g_client;
 
     // Get a new request.
 {% if !fn.isReturnValue %}
-    RequestContext request = g_client->createRequest(true);
+    RequestContext request = mClient->createRequest(true);
 {% else %}
-    RequestContext request = g_client->createRequest(false);
+    RequestContext request = mClient->createRequest(false);
 {% endif -- isReturnValue %}
 
     // Encode the request.
@@ -98,7 +105,7 @@ extern ClientManager *g_client;
 {% endif -- isSendValue %}
 {$clientIndent}    // Send message to server
 {$clientIndent}    // Codec status is checked inside this function.
-{$clientIndent}    g_client->performRequest(request);
+{$clientIndent}    mClient->performRequest(request);
 {% if fn.isReturnValue %}
 {%  if fn.needTempVariableClient %}
 
@@ -140,15 +147,15 @@ extern ClientManager *g_client;
 {% endif -- generateAllocErrorChecks %}
 
     // Dispose of the request.
-    g_client->releaseRequest(request);
+    mClient->releaseRequest(request);
 {% if generateErrorChecks %}
 
     // Invoke error handler callback function
-    g_client->callErrorHandler(err, {$functionIDName});
+    mClient->callErrorHandler(err, {$functionIDName});
 {% endif -- generateErrorChecks %}
 
 #if ERPC_PRE_POST_ACTION
-    pre_post_action_cb postCB = g_client->getPostCB();
+    pre_post_action_cb postCB = mClient->getPostCB();
     if (postCB)
     {
         postCB();
@@ -181,8 +188,28 @@ static {$callbackType.prototype}
 
 {% endfor %}
 {% for iface in group.interfaces %}
-// {$iface.name}_client_t constructor.
-{$iface.name}_client_t::{$iface.name}_client_t(const char *ip, const int port) : m_ip(ip), m_port(port) {}
+// {$iface.name}_client constructor.
+{$iface.name}_client::{$iface.name}_client() {
+    ManuallyConstructed<ClientManager> s_client
+    ManuallyConstructed<BasicCodecFactory> s_codecFactory;
+    ManuallyConstructed<Crc16> s_crc16;
+    erpc_assert(transport);
+
+    Transport *castedTransport;
+
+    // Init factories.
+    s_codecFactory.construct();
+
+    // Init client manager with the provided transport.
+    s_client.construct();
+    castedTransport = reinterpret_cast<Transport *>(transport);
+    s_crc16.construct();
+    castedTransport->setCrc16(s_crc16.get());
+    s_client->setTransport(castedTransport);
+    s_client->setCodecFactory(s_codecFactory);
+    s_client->setMessageBufferFactory(reinterpret_cast<MessageBufferFactory *>(message_buffer_factory));
+    mClient = s_client;
+}
 {%  for fn in iface.functions %}
 
 // {$iface.name} interface {$fn.name} function client shim.
@@ -196,3 +223,4 @@ static {$callbackType.prototype}
 }
 {%  endfor -- fn %}
 {% endfor -- iface %}
+}

--- a/erpcgen/src/templates/cpp_client_source.template
+++ b/erpcgen/src/templates/cpp_client_source.template
@@ -1,0 +1,198 @@
+{% if mlComment != "" %}
+{$mlComment}
+
+{% endif %}
+{$commonHeader()}
+
+#include "erpc_client_manager.h"
+#if ERPC_ALLOCATION_POLICY == ERPC_ALLOCATION_POLICY_DYNAMIC
+#include "erpc_port.h"
+#endif
+#include "{$codecHeader}"
+extern "C"
+{
+#include "{$commonHeaderName}.h"
+{% if groupNames %}
+// import callbacks declaration from other groups
+{%  for name in groupNames if name != group.name %}
+#include "{$outputFilename}_{$name}.h"
+{%  endfor %}
+{% endif %}
+}
+
+{$checkVersion()}
+{$>checkCrc()}
+using namespace erpc;
+using namespace std;
+
+extern ClientManager *g_client;
+{$generateCrcVariable()}
+{$> setSharedMemAddresses()}
+{% if unitTest %}
+{$> callbackTable(functions)}
+{% endif %}
+{$> constantsDefinitions(consts)}
+{$> symbolHeader(group.symbolsMap.symbolsToServer, "serial", "def")}
+{$> symbolSource(group.symbolsMap.symbolsToServer, "serial", "def")}
+{$> symbolHeader(group.symbolsMap.symbolsToClient, "deserial", "def")}
+{$> symbolSource(group.symbolsMap.symbolsToClient, "deserial", "def")}
+{$> symbolHeader(group.symbolsMap.symbolsToServer, "serial", "noSharedMem")}
+{$> symbolSource(group.symbolsMap.symbolsToServer, "serial", "noSharedMem")}
+{$> symbolHeader(group.symbolsMap.symbolsToClient, "deserial", "noSharedMem")}
+{$> symbolSource(group.symbolsMap.symbolsToClient, "deserial", "noSharedMem")}
+{% def clientShimCode(fn, serverIDName, functionIDName) ------------------------- clientShimCode(fn, serverIDName, functionIDName) %}
+{% set clientIndent = "" >%}
+{% if generateErrorChecks %}
+    erpc_status_t err = kErpcStatus_Success;
+
+{% endif -- generateErrorChecks %}
+{% if fn.returnValue.type.isNotVoid %}
+    {$fn.returnValue.resultVariable}{% if fn.returnValue.isNullReturnType %} = NULL{% endif %};
+{% endif -- isNotVoid %}
+
+#if ERPC_PRE_POST_ACTION
+    pre_post_action_cb preCB = g_client->getPreCB();
+    if (preCB)
+    {
+        preCB();
+    }
+#endif
+
+    // Get a new request.
+{% if !fn.isReturnValue %}
+    RequestContext request = g_client->createRequest(true);
+{% else %}
+    RequestContext request = g_client->createRequest(false);
+{% endif -- isReturnValue %}
+
+    // Encode the request.
+{% if codecClass == "Codec" %}
+    {$codecClass} * codec = request.getCodec();
+{% else %}
+    {$codecClass} * codec = static_cast<{$codecClass} *>(request.getCodec());
+{% endif %}
+
+{% if generateAllocErrorChecks %}
+{%  set clientIndent = "    " >%}
+    if (codec == NULL)
+    {
+        err = kErpcStatus_MemoryError;
+    }
+    else
+    {
+{% endif -- generateErrorChecks %}
+{$clientIndent}    codec->startWriteMessage({% if not fn.isReturnValue %}kOnewayMessage{% else %}kInvocationMessage{% endif %}, {$serverIDName}, {$functionIDName}, request.getSequence());
+
+{% if fn.isSendValue %}
+{%  for param in fn.parameters if (param.serializedDirection == "" || param.serializedDirection == OutDirection || param.referencedName != "") %}
+{%   if param.isNullable %}
+{$ addIndent(clientIndent & "    ", f_paramIsNullableEncode(param))}
+
+{%   else -- isNullable %}
+{%    if param.direction != OutDirection %}
+{$addIndent(clientIndent & "    ", param.coderCall.encode(param.coderCall))}
+
+{%    endif -- param != OutDirection %}
+{%   endif -- isNullable %}
+{%  endfor -- fn parameters %}
+{% endif -- isSendValue %}
+{$clientIndent}    // Send message to server
+{$clientIndent}    // Codec status is checked inside this function.
+{$clientIndent}    g_client->performRequest(request);
+{% if fn.isReturnValue %}
+{%  if fn.needTempVariableClient %}
+
+{$clientIndent}    int32_t _tmp_local;
+{%  endif %}
+{%  for param in fn.parametersToClient if (param.serializedDirection == "" || param.serializedDirection == InDirection || param.referencedName != "") %}
+
+{%   if param.isNullable %}
+{% if ((source == "client") && (param.direction != ReturnDirection) && (empty(param.lengthName) == false)) %}
+{%  set lengthNameCon = ") && (" & param.lengthName & " != NULL)" >%}
+{% else %}
+{%  set lengthNameCon = "" >%}
+{% endif %}
+{$clientIndent}    if ({% if lengthNameCon != "" %}({% endif %}{$param.nullableName} != NULL{$lengthNameCon})
+{$clientIndent}    {
+{$addIndent(clientIndent & "        ", param.coderCall.decode(param.coderCall))}
+        }
+{%   else -- notNullable %}
+{$addIndent(clientIndent & "    ", param.coderCall.decode(param.coderCall))}
+{%   endif -- isNullable %}
+{%  endfor -- fn parametersToClient %}
+{%  if fn.returnValue.type.isNotVoid %}
+
+{%   if fn.returnValue.isNullable %}
+{$clientIndent}    bool isNull;
+{$addIndent(clientIndent & "    ", f_paramIsNullableDecode(fn.returnValue))}
+{%   else -- isNullable %}
+{$> addIndent(clientIndent & "    ", allocMem(fn.returnValue.firstAlloc))}
+{$addIndent(clientIndent & "    ", fn.returnValue.coderCall.decode(fn.returnValue.coderCall))}
+{%   endif -- isNullable %}
+{%  endif -- isNotVoid %}
+{% endif -- isReturnValue %}
+{% if generateErrorChecks %}
+
+{$clientIndent}    err = codec->getStatus();
+{% endif -- generateErrorChecks %}
+{%    if generateAllocErrorChecks %}
+    }
+{% endif -- generateAllocErrorChecks %}
+
+    // Dispose of the request.
+    g_client->releaseRequest(request);
+{% if generateErrorChecks %}
+
+    // Invoke error handler callback function
+    g_client->callErrorHandler(err, {$functionIDName});
+{% endif -- generateErrorChecks %}
+
+#if ERPC_PRE_POST_ACTION
+    pre_post_action_cb postCB = g_client->getPostCB();
+    if (postCB)
+    {
+        postCB();
+    }
+#endif
+
+{% if generateErrorChecks && fn.returnValue.type.isNotVoid %}
+{%  if empty(fn.returnValue.errorReturnValue) == false && fn.returnValue.isNullReturnType == false %}
+
+    if (err != kErpcStatus_Success)
+    {
+        result = {$fn.returnValue.errorReturnValue};
+    }
+{%  endif %}
+{% endif -- generateErrorChecks %}
+
+    return{% if fn.returnValue.type.isNotVoid %} result{% endif -- isNotVoid %};
+{% enddef --------------------------------------------------------------------------------- clientShimCode(fn, serverIDName, functionIDName) %}
+{% for callbackType in group.callbacks %}
+// Common function for serializing and deserializing callback functions of same type.
+static {$callbackType.prototype};
+
+{% endfor %}
+{% for callbackType in group.callbacks %}
+// Common function for serializing and deserializing callback functions of same type.
+static {$callbackType.prototype}
+{
+{$ clientShimCode(callbackType, "serviceID", "functionID") >}
+}
+
+{% endfor %}
+{% for iface in group.interfaces %}
+// {$iface.name}_client_t constructor.
+{$iface.name}_client_t::{$iface.name}_client_t(const char *ip, const int port) : m_ip(ip), m_port(port) {}
+{%  for fn in iface.functions %}
+
+// {$iface.name} interface {$fn.name} function client shim.
+{$fn.prototype}
+{
+{%   if fn.isCallback %}
+    {% if fn.returnValue.type.isNotVoid %}return {% endif %}{$fn.callbackFName}(k{$iface.name}_service_id, k{$iface.name}_{$fn.name}_id{% for param in fn.parameters %}, {$param.name}{% endfor %});
+{%   else -- fn.isCallback >%}
+{$ clientShimCode(fn, "k"& iface.name & "_service_id", "k" & iface.name & "_" & fn.name & "_id") >}
+{%   endif -- fn.isCallback >%}
+}
+{%  endfor -- fn %}
+{% endfor -- iface %}

--- a/erpcgen/src/templates/cpp_common_header.template
+++ b/erpcgen/src/templates/cpp_common_header.template
@@ -22,6 +22,8 @@
 #include <stdint.h>
 #include "erpc_version.h"
 #include "erpc_client_manager.h"
+#include "erpc_transport_setup.h"
+#include "erpc_mbf_setup.h"
 
 {% if empty(crc16) == false %}
 #include "erpc_crc16.h"
@@ -37,7 +39,7 @@
 #if !defined(ERPC_TYPE_DEFINITIONS)
 #define ERPC_TYPE_DEFINITIONS
 {% if not empty(enums) %}
-
+using namespace erpc;
 namespace {$iface.name} {
 // Enumerators data types declarations
 {%  for enum in enums %}

--- a/erpcgen/src/templates/cpp_common_header.template
+++ b/erpcgen/src/templates/cpp_common_header.template
@@ -21,6 +21,8 @@
 #include <stddef.h>
 #include <stdint.h>
 #include "erpc_version.h"
+#include "erpc_client_manager.h"
+
 {% if empty(crc16) == false %}
 #include "erpc_crc16.h"
 {% endif  -- empty(crc16) == false %}
@@ -36,6 +38,7 @@
 #define ERPC_TYPE_DEFINITIONS
 {% if not empty(enums) %}
 
+namespace {$iface.name} {
 // Enumerators data types declarations
 {%  for enum in enums %}
 {% if enum.name != "" %}
@@ -125,20 +128,18 @@ enum _{$iface.name}_ids
 class {$iface.name}_client
 {
 private:
-    const char *m_ip;
-    const int m_port;
+    ClientManager* mClient;
     
 public:
-    {$iface.name}_client(const char *ip, const int port);
+    {$iface.name}_client(erpc_transport_t transport, erpc_mbf_t message_buffer_factory);
 
 {%  for fn in iface.functions if fn.isNonExternalFunction == true %}
-    {$> fn.mlComment}
-    {$fn.prototype};{$fn.ilComment}{$loop.addNewLineIfNotLast}
+    {$fn.prototype_no_scope};{$fn.ilComment}{$loop.addNewLineIfNotLast}
 {%  endfor -- functions %}
 };
 //@}{$iface.ilComment}
 {% endfor -- iface %}
 
 {% endif -- genCommonTypesFile %}
-
+}
 #endif // {$commonGuardMacro}

--- a/erpcgen/src/templates/cpp_common_header.template
+++ b/erpcgen/src/templates/cpp_common_header.template
@@ -1,0 +1,144 @@
+{% if mlComment != ""%}
+{$mlComment}
+
+{% endif %}
+{$commonHeader()}
+
+#if !defined({$commonGuardMacro})
+#define {$commonGuardMacro}
+{% if usedUnionType %}
+
+#if defined(__CC_ARM) || defined(__ARMCC_VERSION)
+#pragma anon_unions
+#endif
+{% endif -- usedUnionType %}
+
+{% if not commonTypesFile == "" %}
+// Common types header file
+#include "{$commonTypesFile}"
+{% else %}
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include "erpc_version.h"
+{% if empty(crc16) == false %}
+#include "erpc_crc16.h"
+{% endif  -- empty(crc16) == false %}
+{% for inc in includes %}
+#include "{$inc}"
+{% endfor -- includes %}
+
+{$checkVersion()}
+{$>checkCrc()}
+{% endif -- not commonTypesFile %}
+{% if commonTypesFile == "" %}
+#if !defined(ERPC_TYPE_DEFINITIONS)
+#define ERPC_TYPE_DEFINITIONS
+{% if not empty(enums) %}
+
+// Enumerators data types declarations
+{%  for enum in enums %}
+{% if enum.name != "" %}
+{% endif %}
+{$> enum.mlComment}
+{%   if enum.name %}typedef {% endif --enum.name  %}enum{$addIndent(" ", enum.name)}
+{
+{%   for enumMember in enum.members %}
+{$> addIndent("    ", enumMember.mlComment)}
+    {$enumMember.memberDeclaration}{$enumMember.ilComment}
+{%   endfor -- enumsMembers %}
+}{$addIndent(" ", enum.name)};{$enum.ilComment}{$loop.addNewLineIfNotLast}
+{%  endfor -- enums %}
+{% endif -- enums %}
+{% if not empty(aliases) %}
+
+// Aliases data types declarations
+{%  for alias in aliases %}
+{$> alias.mlComment}
+{%   if alias.typenameName == "" %}
+typedef {$alias.unnamedType}
+{
+{%    for mem in alias.unnamed.members %}
+    {$mem.memberDeclaration}
+{%    endfor -- alias.unnamed.members %}
+} {$alias.unnamedName};
+{%   else -- alias.typenameName %}
+typedef {$alias.typenameName};{$alias.ilComment}
+{%   endif -- alias.typenameName %}
+{%  endfor -- aliases %}
+{% endif -- aliases %}
+{% if nonExternalStructUnion %}
+
+// Structures/unions data types declarations
+{%  for us in symbols %}
+{%   if !us.isExternal %}
+{%    if us.type == "struct" %}
+{$> us.mlComment}
+struct {$us.name}
+{
+{%     for mem in us.members %}
+{$> addIndent("    ", mem.mlComment)}
+    {$mem.memberDeclaration}{$mem.ilComment}
+{$> addIndent("    ", mem.elementsCount)}
+{%     endfor %}
+};{$us.ilComment}{$loop.addNewLineIfNotLast}
+{%    else -- us.type == "union" %}
+{$> us.mlComment}
+union {$us.name}
+{
+{$ addIndent("    ", unionMembersDeclaration(us))}
+};{$us.ilComment}{$loop.addNewLineIfNotLast}
+{%    endif -- us.type == "union/struct" %}
+{%   endif -- !us.isExternal %}
+{%  endfor -- symbols %}
+
+{% endif -- nonExternalStruct || nonExternalUnion %}
+{% if not empty(consts) %}
+
+// Constant variable declarations
+{%  for c in consts %}
+{$> c.mlComment}
+extern const {$c.typeAndName};{$c.ilComment}{$loop.addNewLineIfNotLast}
+{%  endfor -- consts %}
+{% endif -- consts %}
+
+#endif // ERPC_TYPE_DEFINITIONS
+{% endif -- commonTypesFile %}
+
+{% if not genCommonTypesFile %}
+{% for iface in group.interfaces %}
+/*! @brief {$iface.name} identifiers */
+enum _{$iface.name}_ids
+{
+    k{$iface.name}_service_id = {$iface.id},
+{%  for fn in iface.functions %}
+    k{$iface.name}_{$fn.name}_id = {$fn.id},
+{%  endfor %}
+};
+
+{% endfor %}
+{% for iface in group.interfaces if iface.isNonExternalInterface == true %}
+
+{$> iface.mlComment}
+//! @name {$iface.name}
+//@{
+class {$iface.name}_client
+{
+private:
+    const char *m_ip;
+    const int m_port;
+    
+public:
+    {$iface.name}_client(const char *ip, const int port);
+
+{%  for fn in iface.functions if fn.isNonExternalFunction == true %}
+    {$> fn.mlComment}
+    {$fn.prototype};{$fn.ilComment}{$loop.addNewLineIfNotLast}
+{%  endfor -- functions %}
+};
+//@}{$iface.ilComment}
+{% endfor -- iface %}
+
+{% endif -- genCommonTypesFile %}
+
+#endif // {$commonGuardMacro}

--- a/erpcgen/src/templates/cpp_crc.template
+++ b/erpcgen/src/templates/cpp_crc.template
@@ -1,0 +1,15 @@
+{% if mlComment != ""%}
+{$mlComment}
+
+{% endif %}
+{$commonHeader()}
+#if !defined({$crcGuardMacro})
+#define {$crcGuardMacro}
+
+#if !defined(ERPC_GENERATED_CRC)
+#define ERPC_GENERATED_CRC {$crc16}
+#else
+#error "Macro 'ERPC_GENERATED_CRC' shouldn't be defined at this moment."
+#endif
+
+#endif // {$crcGuardMacro}

--- a/erpcgen/src/types/Annotation.h
+++ b/erpcgen/src/types/Annotation.h
@@ -32,7 +32,8 @@ public:
     {
         kAll,
         kC,
-        kPython
+        kPython,
+        kCPP,
     };
 
     /*!


### PR DESCRIPTION
The original C client code used global variables for the client and all of the methods would pollute the global namespace, making including the client into more advanced tech stacks gross. This PR creates a CPP version of the client, which incapsulates all of the endpoints and client connections into a single class, similar to how the python client works.